### PR TITLE
Support for WinFormsTheoryAttribute

### DIFF
--- a/src/Xunit.StaFact.Tests/desktop/WinFormsTheoryTests.cs
+++ b/src/Xunit.StaFact.Tests/desktop/WinFormsTheoryTests.cs
@@ -10,6 +10,8 @@ using System.Windows.Forms;
 using System.Windows.Threading;
 using Xunit;
 
+#pragma warning disable xUnit1008
+
 public class WinFormsTheoryTests
 {
     [WinFormsTheory]
@@ -36,7 +38,7 @@ public class WinFormsTheoryTests
         await Task.Yield();
         Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState()); // still there
         Assert.IsType<WindowsFormsSynchronizationContext>(SynchronizationContext.Current);
-        Assert.True(arg == 0 || arg == 1);
+        Assert.False(arg == 0 || arg == 1);
     }
 }
 

--- a/src/Xunit.StaFact.Tests/desktop/WinFormsTheoryTests.cs
+++ b/src/Xunit.StaFact.Tests/desktop/WinFormsTheoryTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE.txt file in the project root for full license information.
+
+#if !NET45
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.Windows.Threading;
+using Xunit;
+
+public class WinFormsTheoryTests
+{
+    [WinFormsTheory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public async Task WinFormsTheory_OnSTAThread(int arg)
+    {
+        Assert.IsType<WindowsFormsSynchronizationContext>(SynchronizationContext.Current);
+        Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
+        await Task.Yield();
+        Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState()); // still there
+        Assert.IsType<WindowsFormsSynchronizationContext>(SynchronizationContext.Current);
+        Assert.True(arg == 0 || arg == 1);
+    }
+
+    [Trait("Category", "FailureExpected")]
+    [WinFormsTheory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public async Task WinFormsTheoryFails(int arg)
+    {
+        Assert.IsType<WindowsFormsSynchronizationContext>(SynchronizationContext.Current);
+        Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
+        await Task.Yield();
+        Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState()); // still there
+        Assert.IsType<WindowsFormsSynchronizationContext>(SynchronizationContext.Current);
+        Assert.True(arg == 0 || arg == 1);
+    }
+}
+
+#endif

--- a/src/Xunit.StaFact.Tests/desktop/WpfTheoryTests.cs
+++ b/src/Xunit.StaFact.Tests/desktop/WpfTheoryTests.cs
@@ -1,10 +1,14 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the Ms-PL license. See LICENSE.txt file in the project root for full license information.
 
+#if !NET45
+
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Threading;
 using Xunit;
+
+#pragma warning disable xUnit1008
 
 public class WpfTheoryTests
 {
@@ -35,3 +39,5 @@ public class WpfTheoryTests
         Assert.False(arg == 0 || arg == 1);
     }
 }
+
+#endif

--- a/src/Xunit.StaFact/Sdk.Desktop/WinFormsTheoryDiscoverer.cs
+++ b/src/Xunit.StaFact/Sdk.Desktop/WinFormsTheoryDiscoverer.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE.txt file in the project root for full license information.
+
+#if NET452 || NET461
+
+namespace Xunit.Sdk
+{
+    using System.Collections.Generic;
+    using Abstractions;
+
+    /// <summary>
+    /// The discovery class for <see cref="WinFormsTheoryAttribute"/>
+    /// </summary>
+    public class WinFormsTheoryDiscoverer : TheoryDiscoverer
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WinFormsTheoryDiscoverer"/> class.
+        /// </summary>
+        /// <param name="diagnosticMessageSink">The diagnostic message sink.</param>
+        public WinFormsTheoryDiscoverer(IMessageSink diagnosticMessageSink)
+            : base(diagnosticMessageSink)
+        {
+        }
+
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)
+        {
+            yield return new UITestCase(UITestCase.SyncContextType.WinForms, this.DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, dataRow);
+        }
+
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
+        {
+            yield return new WinFormsTheoryTestCase(this.DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod);
+        }
+    }
+}
+
+#endif

--- a/src/Xunit.StaFact/Sdk.Desktop/WinFormsTheoryDiscoverer.cs
+++ b/src/Xunit.StaFact/Sdk.Desktop/WinFormsTheoryDiscoverer.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the Ms-PL license. See LICENSE.txt file in the project root for full license information.
 
-#if NET452 || NET461
+#if !NET45
 
 namespace Xunit.Sdk
 {
@@ -29,7 +29,7 @@ namespace Xunit.Sdk
 
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
         {
-            yield return new WinFormsTheoryTestCase(this.DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod);
+            yield return new WinFormsTheoryTestCase(this.DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), TestMethodDisplayOptions.None, testMethod);
         }
     }
 }

--- a/src/Xunit.StaFact/Sdk.Desktop/WinFormsTheoryTestCase.cs
+++ b/src/Xunit.StaFact/Sdk.Desktop/WinFormsTheoryTestCase.cs
@@ -11,8 +11,8 @@ namespace Xunit.Sdk
 
     public class WinFormsTheoryTestCase : XunitTheoryTestCase
     {
-        public WinFormsTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod)
-            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod)
+        public WinFormsTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod)
         {
         }
 

--- a/src/Xunit.StaFact/Sdk.Desktop/WinFormsTheoryTestCaseRunner.cs
+++ b/src/Xunit.StaFact/Sdk.Desktop/WinFormsTheoryTestCaseRunner.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE.txt file in the project root for full license information.
+
+#if !NET45
+
+namespace Xunit.Sdk
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Threading;
+    using Xunit.Abstractions;
+
+    public class WinFormsTheoryTestCaseRunner : XunitTheoryTestCaseRunner
+    {
+        public WinFormsTheoryTestCaseRunner(IXunitTestCase testCase, string displayName, string skipReason, object[] constructorArguments, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+            : base(testCase, displayName, skipReason, constructorArguments, diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource)
+        {
+        }
+
+        protected override XunitTestRunner CreateTestRunner(ITest test, IMessageBus messageBus, Type testClass, object[] constructorArguments, MethodInfo testMethod, object[] testMethodArguments, string skipReason, IReadOnlyList<BeforeAfterTestAttribute> beforeAfterAttributes, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+            => new UITestRunner(test, messageBus, testClass, constructorArguments, testMethod, testMethodArguments, skipReason, beforeAfterAttributes, aggregator, cancellationTokenSource, DispatcherSynchronizationContextAdapter.Default);
+    }
+}
+
+#endif

--- a/src/Xunit.StaFact/Sdk.Desktop/WinFormsTheoryTestCaseRunner.cs
+++ b/src/Xunit.StaFact/Sdk.Desktop/WinFormsTheoryTestCaseRunner.cs
@@ -19,7 +19,7 @@ namespace Xunit.Sdk
         }
 
         protected override XunitTestRunner CreateTestRunner(ITest test, IMessageBus messageBus, Type testClass, object[] constructorArguments, MethodInfo testMethod, object[] testMethodArguments, string skipReason, IReadOnlyList<BeforeAfterTestAttribute> beforeAfterAttributes, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
-            => new UITestRunner(test, messageBus, testClass, constructorArguments, testMethod, testMethodArguments, skipReason, beforeAfterAttributes, aggregator, cancellationTokenSource, DispatcherSynchronizationContextAdapter.Default);
+            => new UITestRunner(test, messageBus, testClass, constructorArguments, testMethod, testMethodArguments, skipReason, beforeAfterAttributes, aggregator, cancellationTokenSource, WinFormsSynchronizationContextAdapter.Default);
     }
 }
 

--- a/src/Xunit.StaFact/Sdk.Desktop/WinFormsfTheoryTestCase.cs
+++ b/src/Xunit.StaFact/Sdk.Desktop/WinFormsfTheoryTestCase.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE.txt file in the project root for full license information.
+
+#if !NET45
+
+namespace Xunit.Sdk
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Abstractions;
+
+    public class WinFormsTheoryTestCase : XunitTheoryTestCase
+    {
+        public WinFormsTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod)
+            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod)
+        {
+        }
+
+        public override Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+            => new WinFormsTheoryTestCaseRunner(this, this.DisplayName, this.SkipReason, constructorArguments, diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource).RunAsync();
+    }
+}
+
+#endif

--- a/src/Xunit.StaFact/WinFormsFactAttribute.cs
+++ b/src/Xunit.StaFact/WinFormsFactAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the Ms-PL license. See LICENSE.txt file in the project root for full license information.
 
-#if NETFRAMEWORK || NETCOREAPP
-
 namespace Xunit
 {
     using System;
@@ -18,5 +16,3 @@ namespace Xunit
     {
     }
 }
-
-#endif

--- a/src/Xunit.StaFact/WinFormsTheoryAttribute.cs
+++ b/src/Xunit.StaFact/WinFormsTheoryAttribute.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the Ms-PL license. See LICENSE.txt file in the project root for full license information.
 
-//#if NET452
+#if !NET45
 
 namespace Xunit
 {
@@ -19,4 +19,4 @@ namespace Xunit
     }
 }
 
-//#endif
+#endif

--- a/src/Xunit.StaFact/WinFormsTheoryAttribute.cs
+++ b/src/Xunit.StaFact/WinFormsTheoryAttribute.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE.txt file in the project root for full license information.
+
+//#if NET452
+
+namespace Xunit
+{
+    using System;
+    using Xunit.Sdk;
+
+    /// <summary>
+    /// Identifies an xunit theory that starts on an STA thread
+    /// with a WinForms SynchronizationContext.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    [XunitTestCaseDiscoverer("Xunit.Sdk.WinFormsTheoryDiscoverer", ThisAssembly.AssemblyName)]
+    public class WinFormsTheoryAttribute : TheoryAttribute
+    {
+    }
+}
+
+//#endif

--- a/src/Xunit.StaFact/WpfTheoryAttribute.cs
+++ b/src/Xunit.StaFact/WpfTheoryAttribute.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the Ms-PL license. See LICENSE.txt file in the project root for full license information.
 
-#if NETFRAMEWORK || NETCOREAPP
+#if !NET45
 
 namespace Xunit
 {


### PR DESCRIPTION
```
# Conflicts:
#	src/Xunit.StaFact/WpfTheoryAttribute.cs
#	src/Xunit.StaFact/Xunit.StaFact.csproj
```
there are some conflicts with conditional directives and targets u used. But the winforms tests work fine.