### PR TITLE
Block XUnit thread while UIFactThread is running to ensure XUnit concurrency limitations

### DIFF
--- a/src/Xunit.StaFact.Tests/AssemblyAttributes.cs
+++ b/src/Xunit.StaFact.Tests/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(MaxParallelThreads = Counter.MaxCount)]

--- a/src/Xunit.StaFact.Tests/ParallelExecutionLimit/Counter.cs
+++ b/src/Xunit.StaFact.Tests/ParallelExecutionLimit/Counter.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading;
+
+public static class Counter
+{
+    public const int MaxCount = 2;
+
+    private static long counter;
+
+    public static void Increment()
+    {
+        var count = Interlocked.Increment(ref counter);
+        if (count > MaxCount)
+        {
+            throw new InvalidOperationException(
+                $"The number of concurrent tests ({counter}) is greater than allowed ({MaxCount}).");
+        }
+    }
+
+    public static void Decrement()
+    {
+        Interlocked.Decrement(ref counter);
+    }
+}

--- a/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest01.cs
+++ b/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest01.cs
@@ -1,0 +1,58 @@
+using Xunit;
+
+public class UITest01 : UITestBase
+{
+    [UIFact]
+    public void Test1()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test2()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test3()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test4()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test5()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test6()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test7()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test8()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test9()
+    {
+        TestMethod();
+    }
+}

--- a/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest02.cs
+++ b/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest02.cs
@@ -1,0 +1,58 @@
+using Xunit;
+
+public class UITest02 : UITestBase
+{
+    [UIFact]
+    public void Test1()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test2()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test3()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test4()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test5()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test6()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test7()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test8()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test9()
+    {
+        TestMethod();
+    }
+}

--- a/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest03.cs
+++ b/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest03.cs
@@ -1,0 +1,58 @@
+using Xunit;
+
+public class UITest03 : UITestBase
+{
+    [UIFact]
+    public void Test1()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test2()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test3()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test4()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test5()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test6()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test7()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test8()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test9()
+    {
+        TestMethod();
+    }
+}

--- a/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest04.cs
+++ b/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest04.cs
@@ -1,0 +1,58 @@
+using Xunit;
+
+public class UITest04 : UITestBase
+{
+    [UIFact]
+    public void Test1()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test2()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test3()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test4()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test5()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test6()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test7()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test8()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test9()
+    {
+        TestMethod();
+    }
+}

--- a/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest05.cs
+++ b/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest05.cs
@@ -1,0 +1,58 @@
+using Xunit;
+
+public class UITest05 : UITestBase
+{
+    [UIFact]
+    public void Test1()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test2()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test3()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test4()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test5()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test6()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test7()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test8()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test9()
+    {
+        TestMethod();
+    }
+}

--- a/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest06.cs
+++ b/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest06.cs
@@ -1,0 +1,58 @@
+using Xunit;
+
+public class UITest06 : UITestBase
+{
+    [UIFact]
+    public void Test1()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test2()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test3()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test4()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test5()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test6()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test7()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test8()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test9()
+    {
+        TestMethod();
+    }
+}

--- a/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest07.cs
+++ b/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest07.cs
@@ -1,0 +1,58 @@
+using Xunit;
+
+public class UITest07 : UITestBase
+{
+    [UIFact]
+    public void Test1()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test2()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test3()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test4()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test5()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test6()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test7()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test8()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test9()
+    {
+        TestMethod();
+    }
+}

--- a/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest08.cs
+++ b/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest08.cs
@@ -1,0 +1,58 @@
+using Xunit;
+
+public class UITest08 : UITestBase
+{
+    [UIFact]
+    public void Test1()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test2()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test3()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test4()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test5()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test6()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test7()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test8()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test9()
+    {
+        TestMethod();
+    }
+}

--- a/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest09.cs
+++ b/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest09.cs
@@ -1,0 +1,58 @@
+using Xunit;
+
+public class UITest09 : UITestBase
+{
+    [UIFact]
+    public void Test1()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test2()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test3()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test4()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test5()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test6()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test7()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test8()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test9()
+    {
+        TestMethod();
+    }
+}

--- a/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest10.cs
+++ b/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITest10.cs
@@ -1,0 +1,58 @@
+using Xunit;
+
+public class UITest10 : UITestBase
+{
+    [UIFact]
+    public void Test1()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test2()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test3()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test4()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test5()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test6()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test7()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test8()
+    {
+        TestMethod();
+    }
+
+    [UIFact]
+    public void Test9()
+    {
+        TestMethod();
+    }
+}

--- a/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITestBase.cs
+++ b/src/Xunit.StaFact.Tests/ParallelExecutionLimit/UITestBase.cs
@@ -1,0 +1,19 @@
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+public class UITestBase
+{
+    protected static void TestMethod([CallerMemberName] string name = null)
+    {
+        try
+        {
+            Thread.Sleep(200);
+            Counter.Increment();
+            Thread.Sleep(200);
+        }
+        finally
+        {
+            Counter.Decrement();
+        }
+    }
+}

--- a/src/Xunit.StaFact/Sdk/ThreadRental.cs
+++ b/src/Xunit.StaFact/Sdk/ThreadRental.cs
@@ -49,18 +49,17 @@ namespace Xunit.Sdk
         internal static async Task<ThreadRental> CreateAsync(SyncContextAdapter syncContextAdapter, ITestMethod testMethod)
         {
             var disposalTaskSource = new TaskCompletionSource<object?>();
-            var tcs = new TaskCompletionSource<decimal>();
             var syncContextSource = new TaskCompletionSource<SynchronizationContext>();
             var thread = new Thread(() =>
             {
                 var uiSyncContext = syncContextAdapter.Create();
-                syncContextSource.SetResult(uiSyncContext);
                 if (syncContextAdapter.ShouldSetAsCurrent)
                 {
                     SynchronizationContext.SetSynchronizationContext(uiSyncContext);
                 }
 
                 syncContextAdapter.InitializeThread();
+                syncContextSource.SetResult(uiSyncContext);
                 syncContextAdapter.PumpTill(uiSyncContext, disposalTaskSource.Task);
             });
 

--- a/src/Xunit.StaFact/Sdk/UITestCase.cs
+++ b/src/Xunit.StaFact/Sdk/UITestCase.cs
@@ -4,7 +4,6 @@
 namespace Xunit.Sdk
 {
     using System;
-    using System.Collections.Generic;
     using System.ComponentModel;
     using System.Diagnostics;
     using System.Threading;
@@ -88,16 +87,24 @@ namespace Xunit.Sdk
         }
 
         /// <inheritdoc/>
-        public override async Task<RunSummary> RunAsync(
+        public override Task<RunSummary> RunAsync(
             IMessageSink diagnosticMessageSink,
             IMessageBus messageBus,
             object[] constructorArguments,
             ExceptionAggregator aggregator,
             CancellationTokenSource cancellationTokenSource)
         {
-            using var threadRental = await ThreadRental.CreateAsync(this.Adapter, this.TestMethod);
-            await threadRental.SynchronizationContext;
-            return await new UITestCaseRunner(this, this.DisplayName, this.SkipReason, constructorArguments, this.TestMethodArguments, messageBus, aggregator, cancellationTokenSource, threadRental).RunAsync();
+            var task = Task.Run(async () =>
+            {
+                using ThreadRental threadRental = await ThreadRental.CreateAsync(this.Adapter, this.TestMethod);
+                await threadRental.SynchronizationContext;
+                var runner = new UITestCaseRunner(this, this.DisplayName, this.SkipReason, constructorArguments, this.TestMethodArguments, messageBus, aggregator, cancellationTokenSource, threadRental);
+                return await runner.RunAsync();
+            });
+
+            // We need to block the XUnit thread to ensure it concurrency implementation.
+            task.Wait(TimeSpan.FromMinutes(30));
+            return Task.FromResult(task.Result);
         }
 
         internal static SyncContextAdapter GetAdapter(SyncContextType syncContextType)

--- a/src/Xunit.StaFact/Sdk/UITestCase.cs
+++ b/src/Xunit.StaFact/Sdk/UITestCase.cs
@@ -104,7 +104,8 @@ namespace Xunit.Sdk
                 },
                 cancellationTokenSource.Token);
 
-            // We need to block the XUnit thread to ensure it concurrency implementation.
+            // We need to block the XUnit thread to ensure its concurrency throttle is effective.
+            // See https://github.com/AArnott/Xunit.StaFact/pull/55#issuecomment-826187354 for details.
             RunSummary runSummary = task.GetAwaiter().GetResult();
             return Task.FromResult(runSummary);
         }


### PR DESCRIPTION
The XUnit concurrency limitation is based limited number of threads running tests concurrently.
When `UITestCase` starts new (additional) thread and the test running is `await`ing the `StaFact` thread, the `XUnit` thread is available for another test. Thereby more tests can be executed in parallel then intended by XUnit framework.

This PR, intended to fix #53, introduces additional tests to reproduce the problem.
Further I hope to fix the mentioned problem by blocking the XUnit thread while `StaFact` thread is running the test itself.

So far, I've added fixed time limit of 30 minutes to wait for the test completion to prevent endless waiting.
I'm not sure whether this is either required or the final solution. Maybe you have an idea!?

Finally we have to check what is the "correct" file header for the new files (unit test).
