### PR TITLE
Include owning test name in exception when zombied SyncContext is used

### DIFF
--- a/src/Xunit.StaFact/Sdk.Desktop/DispatcherSynchronizationContextAdapter.cs
+++ b/src/Xunit.StaFact/Sdk.Desktop/DispatcherSynchronizationContextAdapter.cs
@@ -18,7 +18,7 @@ namespace Xunit.Sdk
 
         internal override bool CanCompleteOperations => false;
 
-        internal override SynchronizationContext Create() => new DispatcherSynchronizationContext();
+        internal override SynchronizationContext Create(string name) => new DispatcherSynchronizationContext();
 
         internal override Task WaitForOperationCompletionAsync(SynchronizationContext syncContext)
         {

--- a/src/Xunit.StaFact/Sdk.Desktop/WinFormsSynchronizationContextAdapter.cs
+++ b/src/Xunit.StaFact/Sdk.Desktop/WinFormsSynchronizationContextAdapter.cs
@@ -26,7 +26,7 @@ namespace Xunit.Sdk
 
         internal override bool CanCompleteOperations => false;
 
-        internal override SynchronizationContext Create() => new WindowsFormsSynchronizationContext();
+        internal override SynchronizationContext Create(string name) => new WindowsFormsSynchronizationContext();
 
         internal override Task WaitForOperationCompletionAsync(SynchronizationContext syncContext)
         {

--- a/src/Xunit.StaFact/Sdk/SyncContextAdapter.cs
+++ b/src/Xunit.StaFact/Sdk/SyncContextAdapter.cs
@@ -24,8 +24,9 @@ namespace Xunit.Sdk
         /// <summary>
         /// Creates a new <see cref="SynchronizationContext"/> of the derived type.
         /// </summary>
+        /// <param name="name">The name of the context.</param>
         /// <returns>The new instance.</returns>
-        internal abstract SynchronizationContext Create();
+        internal abstract SynchronizationContext Create(string name);
 
         /// <summary>
         /// Runs code on the test thread before any user code is executed (before the test class is even instantiated).

--- a/src/Xunit.StaFact/Sdk/ThreadRental.cs
+++ b/src/Xunit.StaFact/Sdk/ThreadRental.cs
@@ -50,9 +50,10 @@ namespace Xunit.Sdk
         {
             var disposalTaskSource = new TaskCompletionSource<object?>();
             var syncContextSource = new TaskCompletionSource<SynchronizationContext>();
+            var threadName = $"{testMethod.TestClass.Class.Name}.{testMethod.Method.Name}";
             var thread = new Thread(() =>
             {
-                var uiSyncContext = syncContextAdapter.Create();
+                var uiSyncContext = syncContextAdapter.Create(threadName);
                 if (syncContextAdapter.ShouldSetAsCurrent)
                 {
                     SynchronizationContext.SetSynchronizationContext(uiSyncContext);
@@ -63,7 +64,7 @@ namespace Xunit.Sdk
                 syncContextAdapter.PumpTill(uiSyncContext, disposalTaskSource.Task);
             });
 
-            thread.Name = $"{testMethod.TestClass.Class.Name}.{testMethod.Method.Name}";
+            thread.Name = threadName;
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {

--- a/src/Xunit.StaFact/Sdk/UISynchronizationContext.cs
+++ b/src/Xunit.StaFact/Sdk/UISynchronizationContext.cs
@@ -17,6 +17,7 @@ namespace Xunit.Sdk
         private readonly Queue<KeyValuePair<SendOrPostCallback, object?>> messageQueue = new Queue<KeyValuePair<SendOrPostCallback, object?>>();
         private readonly int mainThread = Environment.CurrentManagedThreadId;
         private readonly AsyncAutoResetEvent workItemDone = new AsyncAutoResetEvent();
+        private readonly string name;
         private readonly bool shouldSetAsCurrent;
         private int activeOperations;
         private bool pumping;
@@ -26,8 +27,9 @@ namespace Xunit.Sdk
         /// <summary>
         /// Initializes a new instance of the <see cref="UISynchronizationContext"/> class.
         /// </summary>
-        public UISynchronizationContext(bool shouldSetAsCurrent)
+        public UISynchronizationContext(string name, bool shouldSetAsCurrent)
         {
+            this.name = name;
             this.shouldSetAsCurrent = shouldSetAsCurrent;
         }
 
@@ -137,7 +139,7 @@ namespace Xunit.Sdk
         {
             if (this.pumpingEnded)
             {
-                throw new InvalidOperationException("The message pump isn't running any more.");
+                throw new InvalidOperationException($"The message pump in '{this.name}' isn't running any more.");
             }
 
             lock (this.messageQueue)
@@ -249,7 +251,7 @@ namespace Xunit.Sdk
             {
             }
 
-            internal override SynchronizationContext Create() => new UISynchronizationContext(this.ShouldSetAsCurrent);
+            internal override SynchronizationContext Create(string name) => new UISynchronizationContext(name, this.ShouldSetAsCurrent);
 
             internal override Task WaitForOperationCompletionAsync(SynchronizationContext syncContext) => ((UISynchronizationContext)syncContext).WaitForOperationCompletionAsync();
 


### PR DESCRIPTION
report the name of the thread if UISynchronizationContext is invoked and pump already ended