### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.github/actions/publish-artifacts/action.yaml
+++ b/.github/actions/publish-artifacts/action.yaml
@@ -32,13 +32,6 @@ runs:
       name: build_logs-${{ runner.os }}
       path: ${{ runner.temp }}/_artifacts/build_logs
     continue-on-error: true
-  - name: 📢 Upload test_logs
-    if: always()
-    uses: actions/upload-artifact@v4
-    with:
-      name: test_logs-${{ runner.os }}
-      path: ${{ runner.temp }}/_artifacts/test_logs
-    continue-on-error: true
   - name: 📢 Upload testResults
     if: always()
     uses: actions/upload-artifact@v4

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup Label="Library.Template">
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
     <PackageVersion Include="xunit" Version="2.4.2" />
   </ItemGroup>
   <ItemGroup>

--- a/tools/Get-ArtifactsStagingDirectory.ps1
+++ b/tools/Get-ArtifactsStagingDirectory.ps1
@@ -4,7 +4,7 @@ Param(
 if ($env:BUILD_ARTIFACTSTAGINGDIRECTORY) {
     $ArtifactStagingFolder = $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 } elseif ($env:RUNNER_TEMP) {
-    $ArtifactStagingFolder = "$env:RUNNER_TEMP\_artifacts"
+    $ArtifactStagingFolder = Join-Path $env:RUNNER_TEMP _artifacts
 } else {
     $ArtifactStagingFolder = [System.IO.Path]::GetFullPath("$PSScriptRoot/../obj/_artifacts")
     if ($CleanIfLocal -and (Test-Path $ArtifactStagingFolder)) {

--- a/tools/artifacts/_stage_all.ps1
+++ b/tools/artifacts/_stage_all.ps1
@@ -11,7 +11,7 @@ param (
     [switch]$AvoidSymbolicLinks
 )
 
-$ArtifactStagingFolder = & "$PSScriptRoot/../../tools/Get-ArtifactsStagingDirectory.ps1" -CleanIfLocal
+$ArtifactStagingFolder = & "$PSScriptRoot/../Get-ArtifactsStagingDirectory.ps1" -CleanIfLocal
 
 function Create-SymbolicLink {
     param (

--- a/tools/artifacts/build_logs.ps1
+++ b/tools/artifacts/build_logs.ps1
@@ -1,4 +1,4 @@
-$ArtifactStagingFolder = & "$PSScriptRoot/../../tools/Get-ArtifactsStagingDirectory.ps1"
+$ArtifactStagingFolder = & "$PSScriptRoot/../Get-ArtifactsStagingDirectory.ps1"
 
 if (!(Test-Path $ArtifactStagingFolder/build_logs)) { return }
 

--- a/tools/artifacts/testResults.ps1
+++ b/tools/artifacts/testResults.ps1
@@ -7,9 +7,10 @@ $result = @{}
 $testRoot = Resolve-Path "$PSScriptRoot\..\..\test"
 $result[$testRoot] = (Get-ChildItem "$testRoot\TestResults" -Recurse -Directory | Get-ChildItem -Recurse -File)
 
-$testlogsPath = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY\test_logs"
+$artifactStaging = & "$PSScriptRoot/../Get-ArtifactsStagingDirectory.ps1"
+$testlogsPath = Join-Path $artifactStaging "test_logs"
 if (Test-Path $testlogsPath) {
-    $result[$testlogsPath] = Get-ChildItem "$testlogsPath\*";
+    $result[$testlogsPath] = Get-ChildItem $testlogsPath -Recurse;
 }
 
 $result


### PR DESCRIPTION
- Fix test logs collection
- Take care to use proper slashes per OS for testing
- Match test assemblies that are built as exe's
- Ensure Expand-Template uses UTF-8 when replacing placeholders.
- Simplify certain ps1 script paths
- Update xunit (#336)
