### PR TITLE
Add support for SkipExceptions property.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,11 +4,11 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <XunitV3LibraryVersion>1.0.0</XunitV3LibraryVersion>
+    <XunitV3LibraryVersion>2.0.0</XunitV3LibraryVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="xunit.v3.extensibility.core" Version="1.0.1" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(MSBuildProjectName)'=='Xunit.StaFact'">
     <PackageVersion Update="xunit.v3.extensibility.core" Version="$(XunitV3LibraryVersion)" />
@@ -16,7 +16,7 @@
   <ItemGroup Label="Library.Template">
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
-    <PackageVersion Include="xunit.v3" Version="1.0.1" />
+    <PackageVersion Include="xunit.v3" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Put repo-specific GlobalPackageReference items in this group. -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,8 +15,11 @@
   </ItemGroup>
   <ItemGroup Label="Library.Template">
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="xunit.analyzers" Version="1.20.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
     <PackageVersion Include="xunit.v3" Version="2.0.0" />
+    <PackageVersion Include="xunit.v3.assert" Version="2.0.0" />
+    <PackageVersion Include="xunit.v3.runner.inproc.console" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Put repo-specific GlobalPackageReference items in this group. -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,18 +8,18 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
+    <PackageVersion Include="xunit.analyzers" Version="1.20.0" />
+    <PackageVersion Include="xunit.v3.assert" Version="2.0.0" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="2.0.0" />
+    <PackageVersion Include="xunit.v3.runner.inproc.console" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(MSBuildProjectName)'=='Xunit.StaFact'">
     <PackageVersion Update="xunit.v3.extensibility.core" Version="$(XunitV3LibraryVersion)" />
   </ItemGroup>
   <ItemGroup Label="Library.Template">
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="xunit.analyzers" Version="1.20.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
     <PackageVersion Include="xunit.v3" Version="2.0.0" />
-    <PackageVersion Include="xunit.v3.assert" Version="2.0.0" />
-    <PackageVersion Include="xunit.v3.runner.inproc.console" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Put repo-specific GlobalPackageReference items in this group. -->

--- a/docfx/docs/getting-started.md
+++ b/docfx/docs/getting-started.md
@@ -9,7 +9,7 @@ Click on the badge to find its latest version and the instructions for consuming
 
 ## Default Fact behavior
 
-[!code-csharp[](../../samples/Samples.cs#Fact)]
+[!code-csharp[](../../samples/SampleTests.cs#Fact)]
 
 ## Usage
 
@@ -18,19 +18,19 @@ Click on the badge to find its latest version and the instructions for consuming
 Best when you need basic UI thread semantics for tests that may run on any OS.
 You'll get an STA thread on Windows.
 
-[!code-csharp[](../../samples/Samples.cs#UIFact)]
+[!code-csharp[](../../samples/SampleTests.cs#UIFact)]
 
 ### WPF
 
 More closely resembles WPF-specific semantics including a WPF-specific @System.Threading.SynchronizationContext.
 
-[!code-csharp[](../../samples/Samples.cs#WpfFact)]
+[!code-csharp[](../../samples/SampleTests.cs#WpfFact)]
 
 ### WinForms
 
 More closely resembles WinForms-specific semantics including a WinForms-specific @System.Threading.SynchronizationContext.
 
-[!code-csharp[](../../samples/Samples.cs#WinFormsFact)]
+[!code-csharp[](../../samples/SampleTests.cs#WinFormsFact)]
 
 ### STA thread
 
@@ -38,4 +38,4 @@ Guarantees the test to run on an STA thread.
 Applicable only on Windows.
 Because no @System.Threading.SynchronizationContext is applied by default, an async test will resume on a threadpool thread instead of the test thread after a yielding await.
 
-[!code-csharp[](../../samples/Samples.cs#STAFact)]
+[!code-csharp[](../../samples/SampleTests.cs#STAFact)]

--- a/samples/SampleTests.cs
+++ b/samples/SampleTests.cs
@@ -3,7 +3,7 @@
 
 using System.Runtime.InteropServices;
 
-public class Samples
+public class SampleTests
 {
     #region UIFact
     /// <summary>

--- a/src/Xunit.StaFact/Sdk/SkippedTestCase.cs
+++ b/src/Xunit.StaFact/Sdk/SkippedTestCase.cs
@@ -44,7 +44,7 @@ public class SkippedTestCase : XunitTestCase
         string? sourceFilePath = null,
         int? sourceLineNumber = null,
         int? timeout = null)
-        : base(testMethod, testCaseDisplayName, uniqueID, @explicit, skipReason, null, null, null, traits, testMethodArguments, sourceFilePath, sourceLineNumber, timeout)
+        : base(testMethod, testCaseDisplayName, uniqueID, @explicit, null, skipReason, null, null, null, traits, testMethodArguments, sourceFilePath, sourceLineNumber, timeout)
     {
     }
 }

--- a/src/Xunit.StaFact/Sdk/UIDelayEnumeratedTestCase.cs
+++ b/src/Xunit.StaFact/Sdk/UIDelayEnumeratedTestCase.cs
@@ -24,6 +24,7 @@ public class UIDelayEnumeratedTestCase : XunitDelayEnumeratedTheoryTestCase, ISe
         string uniqueID,
         bool @explicit,
         bool skipTestWithoutData,
+        Type[]? skipExceptions = null,
         string? skipReason = null,
         Type? skipType = null,
         string? skipUnless = null,
@@ -32,7 +33,7 @@ public class UIDelayEnumeratedTestCase : XunitDelayEnumeratedTheoryTestCase, ISe
         string? sourceFilePath = null,
         int? sourceLineNumber = null,
         int? timeout = null)
-        : base(testMethod, testCaseDisplayName, uniqueID, @explicit, skipTestWithoutData, skipReason, skipType, skipUnless, skipWhen, traits, sourceFilePath, sourceLineNumber, timeout)
+        : base(testMethod, testCaseDisplayName, uniqueID, @explicit, skipTestWithoutData, skipExceptions, skipReason, skipType, skipUnless, skipWhen, traits, sourceFilePath, sourceLineNumber, timeout)
     {
         this.settings = settings;
         this.synchronizationContextType = synchronizationContextType;

--- a/src/Xunit.StaFact/Sdk/UITestCase.cs
+++ b/src/Xunit.StaFact/Sdk/UITestCase.cs
@@ -34,6 +34,7 @@ public class UITestCase : XunitTestCase, ISelfExecutingXunitTestCase
     /// <param name="testCaseDisplayName">The display name for the test case.</param>
     /// <param name="uniqueID">The unique ID for the test case.</param>
     /// <param name="explicit">Indicates whether the test case was marked as explicit.</param>
+    /// <param name="skipExceptions">The value obtained from <see cref="IFactAttribute.SkipExceptions"/>.</param>
     /// <param name="skipReason">The value obtained from <see cref="IFactAttribute.Skip"/>.</param>
     /// <param name="skipType">The value obtained from <see cref="IFactAttribute.SkipType"/>.</param>
     /// <param name="skipUnless">The value obtained from <see cref="IFactAttribute.SkipUnless"/>.</param>
@@ -50,6 +51,7 @@ public class UITestCase : XunitTestCase, ISelfExecutingXunitTestCase
         string testCaseDisplayName,
         string uniqueID,
         bool @explicit,
+        Type[]? skipExceptions = null,
         string? skipReason = null,
         Type? skipType = null,
         string? skipUnless = null,
@@ -59,7 +61,7 @@ public class UITestCase : XunitTestCase, ISelfExecutingXunitTestCase
         string? sourceFilePath = null,
         int? sourceLineNumber = null,
         int? timeout = null)
-        : base(testMethod, testCaseDisplayName, uniqueID, @explicit, skipReason, skipType, skipUnless, skipWhen, traits, testMethodArguments, sourceFilePath, sourceLineNumber, timeout)
+        : base(testMethod, testCaseDisplayName, uniqueID, @explicit, skipExceptions, skipReason, skipType, skipUnless, skipWhen, traits, testMethodArguments, sourceFilePath, sourceLineNumber, timeout)
     {
         this.settings = settings;
         settings.ApplyTraits(this);

--- a/src/Xunit.StaFact/Sdk/Utilities.cs
+++ b/src/Xunit.StaFact/Sdk/Utilities.cs
@@ -15,7 +15,7 @@ internal static class Utilities
         IXunitTestMethod testMethod,
         IFactAttribute factAttribute)
     {
-        (string TestCaseDisplayName, bool Explicit, string? SkipReason, Type? SkipType, string? SkipUnless, string? SkipWhen, int Timeout, string UniqueID, IXunitTestMethod ResolvedTestMethod) details;
+        (string TestCaseDisplayName, bool Explicit, Type[]? SkipExceptions, string? SkipReason, Type? SkipType, string? SkipUnless, string? SkipWhen, int Timeout, string UniqueID, IXunitTestMethod ResolvedTestMethod) details;
         Dictionary<string, HashSet<string>> traits;
 
         details = TestIntrospectionHelper.GetTestCaseDetails(discoveryOptions, testMethod, factAttribute);
@@ -39,6 +39,7 @@ internal static class Utilities
             details.TestCaseDisplayName,
             details.UniqueID,
             details.Explicit,
+            details.SkipExceptions,
             details.SkipReason,
             details.SkipType,
             details.SkipUnless,
@@ -56,7 +57,7 @@ internal static class Utilities
         ITheoryDataRow dataRow,
         object?[] testMethodArguments)
     {
-        (string TestCaseDisplayName, bool Explicit, string? SkipReason, Type? SkipType, string? SkipUnless, string? SkipWhen, int Timeout, string UniqueID, IXunitTestMethod ResolvedTestMethod) details;
+        (string TestCaseDisplayName, bool Explicit, Type[]? SkipExceptions, string? SkipReason, Type? SkipType, string? SkipUnless, string? SkipWhen, int Timeout, string UniqueID, IXunitTestMethod ResolvedTestMethod) details;
         Dictionary<string, HashSet<string>> traits;
 
         details = TestIntrospectionHelper.GetTestCaseDetailsForTheoryDataRow(discoveryOptions, testMethod, theoryAttribute, dataRow, testMethodArguments);
@@ -81,6 +82,7 @@ internal static class Utilities
             details.TestCaseDisplayName,
             details.UniqueID,
             details.Explicit,
+            details.SkipExceptions,
             details.SkipReason,
             details.SkipType,
             details.SkipUnless,
@@ -97,7 +99,7 @@ internal static class Utilities
         IXunitTestMethod testMethod,
         ITheoryAttribute attribute)
     {
-        (string TestCaseDisplayName, bool Explicit, string? SkipReason, Type? SkipType, string? SkipUnless, string? SkipWhen, int Timeout, string UniqueID, IXunitTestMethod ResolvedTestMethod) details;
+        (string TestCaseDisplayName, bool Explicit, Type[]? SkipExceptions, string? SkipReason, Type? SkipType, string? SkipUnless, string? SkipWhen, int Timeout, string UniqueID, IXunitTestMethod ResolvedTestMethod) details;
         Dictionary<string, HashSet<string>> traits;
 
         details = TestIntrospectionHelper.GetTestCaseDetails(discoveryOptions, testMethod, attribute);
@@ -122,6 +124,7 @@ internal static class Utilities
             details.UniqueID,
             details.Explicit,
             attribute.SkipTestWithoutData,
+            details.SkipExceptions,
             details.SkipReason,
             details.SkipType,
             details.SkipUnless,

--- a/test/Xunit.StaFact.Tests.Mac/Xunit.StaFact.Tests.Mac.csproj
+++ b/test/Xunit.StaFact.Tests.Mac/Xunit.StaFact.Tests.Mac.csproj
@@ -20,7 +20,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.analyzers" />
+    <PackageReference Include="xunit.v3.assert" />
+    <PackageReference Include="xunit.v3.extensibility.core" />
+    <PackageReference Include="xunit.v3.runner.inproc.console" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Xunit.StaFact\Xunit.StaFact.csproj" />

--- a/test/Xunit.StaFact.Tests/SkipOnThisException.cs
+++ b/test/Xunit.StaFact.Tests/SkipOnThisException.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+public class SkipOnThisException : Exception
+{
+    public SkipOnThisException()
+    {
+    }
+}

--- a/test/Xunit.StaFact.Tests/StaFactTests.cs
+++ b/test/Xunit.StaFact.Tests/StaFactTests.cs
@@ -11,7 +11,7 @@ public class StaFactTests
         Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
     }
 
-    [StaFact]
+    [DesktopFact]
     public async Task StaWithoutSyncContext()
     {
         Assert.Null(SynchronizationContext.Current);
@@ -23,14 +23,14 @@ public class StaFactTests
         Assert.Equal(ApartmentState.MTA, Thread.CurrentThread.GetApartmentState());
     }
 
-    [StaFact]
+    [DesktopFact]
     public void Sta_Void()
     {
         Assert.Null(SynchronizationContext.Current);
         Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
     }
 
-    [StaFact, Trait("TestCategory", "FailureExpected")]
+    [DesktopFact, Trait("TestCategory", "FailureExpected")]
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
     public async void AsyncVoid_IsNotSupported()
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
@@ -39,7 +39,7 @@ public class StaFactTests
         // async void tests aren't supportable when you have no SynchronizationContext.
     }
 
-    [StaFact, Trait("TestCategory", "FailureExpected")]
+    [DesktopFact, Trait("TestCategory", "FailureExpected")]
     public void JustFailVoid() => throw new InvalidOperationException("Expected failure.");
 
     [DesktopFact]
@@ -55,5 +55,11 @@ public class StaFactTests
     public void FailsAllRetries()
     {
         Assert.Fail("Failure expected.");
+    }
+
+    [DesktopFact(SkipExceptions = [typeof(SkipOnThisException)])]
+    public void CanSkipOnSpecificExceptions()
+    {
+        throw new SkipOnThisException();
     }
 }

--- a/test/Xunit.StaFact.Tests/StaTheoryTests.cs
+++ b/test/Xunit.StaFact.Tests/StaTheoryTests.cs
@@ -12,7 +12,7 @@ public partial class StaTheoryTests
         new object[] { 3, 4 },
     };
 
-    [StaTheory]
+    [DesktopTheory]
     [InlineData(0)]
     [InlineData(1)]
     public async Task StaTheory_OnSTAThread(int arg)
@@ -29,7 +29,7 @@ public partial class StaTheoryTests
     }
 
     [Trait("TestCategory", "FailureExpected")]
-    [StaTheory]
+    [DesktopTheory]
     [InlineData(0)]
     [InlineData(1)]
     public async Task StaTheoryFails(int arg)
@@ -45,7 +45,7 @@ public partial class StaTheoryTests
         Assert.False(arg == 0 || arg == 1);
     }
 
-    [StaTheory]
+    [DesktopTheory]
     [MemberData(nameof(MemberDataSource))]
     public void MemberBasedTheory(int a, int b)
     {
@@ -61,7 +61,7 @@ public partial class StaTheoryTests
         throw new OperationCanceledException();
     }
 
-    [StaTheory]
+    [DesktopTheory]
     [MemberData(nameof(NonSerializableObject.Data), MemberType = typeof(NonSerializableObject))]
     public void ThreadAffinitizedDataObject(NonSerializableObject o)
     {
@@ -93,5 +93,13 @@ public partial class StaTheoryTests
     {
         _ = arg;
         Assert.Fail("Failure expected.");
+    }
+
+    [DesktopTheory(SkipExceptions = [typeof(SkipOnThisException)])]
+    [InlineData(0)]
+    public void CanSkipOnSpecificExceptions(int arg)
+    {
+        _ = arg;
+        throw new SkipOnThisException();
     }
 }

--- a/test/Xunit.StaFact.Tests/UIFactTests.cs
+++ b/test/Xunit.StaFact.Tests/UIFactTests.cs
@@ -40,14 +40,14 @@ public partial class UIFactTests : IDisposable, IAsyncLifetime
         Assert.Same(this.ctorSyncContext, SynchronizationContext.Current);
     }
 
-    [UIFact]
+    [DesktopFact]
     public void CtorAndTestMethodInvokedInSameContext()
     {
         Assert.Equal(this.ctorThreadId, Environment.CurrentManagedThreadId);
         Assert.Same(this.ctorSyncContext, SynchronizationContext.Current);
     }
 
-    [UIFact]
+    [DesktopFact]
     public async Task CtorAndTestMethodInvokedInSameContext_AcrossYields()
     {
         await Task.Yield();
@@ -55,49 +55,49 @@ public partial class UIFactTests : IDisposable, IAsyncLifetime
         Assert.Same(this.ctorSyncContext, SynchronizationContext.Current);
     }
 
-    [UIFact]
+    [DesktopFact]
     public async Task PassAfterYield()
     {
         // This will post to the SynchronizationContext before yielding.
         await Task.Yield();
     }
 
-    [UIFact]
+    [DesktopFact]
     public async Task PassAfterDelay()
     {
         // This won't post to the SynchronizationContext till after the delay.
         await Task.Delay(10);
     }
 
-    [UIFact, Trait("TestCategory", "FailureExpected")]
+    [DesktopFact, Trait("TestCategory", "FailureExpected")]
     public async Task FailAfterYield()
     {
         await Task.Yield();
         Assert.False(true);
     }
 
-    [UIFact, Trait("TestCategory", "FailureExpected")]
+    [DesktopFact, Trait("TestCategory", "FailureExpected")]
     public async Task FailAfterDelay()
     {
         await Task.Delay(10);
         Assert.False(true);
     }
 
-    [UIFact, Trait("TestCategory", "FailureExpected")]
+    [DesktopFact, Trait("TestCategory", "FailureExpected")]
     public async Task FailAfterYield_Task()
     {
         await Task.Yield();
         Assert.False(true);
     }
 
-    [UIFact, Trait("TestCategory", "FailureExpected")]
+    [DesktopFact, Trait("TestCategory", "FailureExpected")]
     public async Task FailAfterDelay_Task()
     {
         await Task.Delay(10);
         Assert.False(true);
     }
 
-    [UIFact]
+    [DesktopFact]
     public async Task UIFact_OnSingleThreadedSyncContext()
     {
         int initialThread = Environment.CurrentManagedThreadId;
@@ -107,7 +107,7 @@ public partial class UIFactTests : IDisposable, IAsyncLifetime
         Assert.Same(syncContext, SynchronizationContext.Current);
     }
 
-    [UIFact]
+    [DesktopFact]
     public async Task SendBackFromOtherThread()
     {
         SynchronizationContext sc = SynchronizationContext.Current ?? throw new InvalidOperationException("No SynchronizationContext");
@@ -126,7 +126,7 @@ public partial class UIFactTests : IDisposable, IAsyncLifetime
         Assert.True(delegateComplete);
     }
 
-    [UIFact]
+    [DesktopFact]
     public async Task SendBackFromOtherThread_Throws()
     {
         SynchronizationContext sc = SynchronizationContext.Current ?? throw new InvalidOperationException("No SynchronizationContext");
@@ -142,7 +142,7 @@ public partial class UIFactTests : IDisposable, IAsyncLifetime
         });
     }
 
-    [UIFact, Trait("TestCategory", "FailureExpected")]
+    [DesktopFact, Trait("TestCategory", "FailureExpected")]
     public void JustFailVoid() => throw new InvalidOperationException("Expected failure.");
 
     [DesktopFact]
@@ -158,6 +158,12 @@ public partial class UIFactTests : IDisposable, IAsyncLifetime
     public void FailsAllRetries()
     {
         Assert.Fail("Failure expected.");
+    }
+
+    [DesktopFact(SkipExceptions = [typeof(SkipOnThisException)])]
+    public void CanSkipOnSpecificExceptions()
+    {
+        throw new SkipOnThisException();
     }
 
     [UISettings(MaxAttempts = 2)]

--- a/test/Xunit.StaFact.Tests/UITheoryTests.cs
+++ b/test/Xunit.StaFact.Tests/UITheoryTests.cs
@@ -40,7 +40,7 @@ public class UITheoryTests : IDisposable, IAsyncLifetime
         Assert.Same(this.ctorSyncContext, SynchronizationContext.Current);
     }
 
-    [UITheory]
+    [DesktopTheory]
     [InlineData(0)]
     public void CtorAndTestMethodInvokedInSameContext(int arg)
     {
@@ -49,7 +49,7 @@ public class UITheoryTests : IDisposable, IAsyncLifetime
         Assert.Equal(0, arg);
     }
 
-    [UITheory]
+    [DesktopTheory]
     [InlineData(0)]
     public async Task CtorAndTestMethodInvokedInSameContext_AcrossYields(int arg)
     {
@@ -59,7 +59,7 @@ public class UITheoryTests : IDisposable, IAsyncLifetime
         Assert.Equal(0, arg);
     }
 
-    [UITheory]
+    [DesktopTheory]
     [InlineData(0)]
     public async Task PassAfterYield(int arg)
     {
@@ -68,7 +68,7 @@ public class UITheoryTests : IDisposable, IAsyncLifetime
         Assert.Equal(0, arg);
     }
 
-    [UITheory]
+    [DesktopTheory]
     [InlineData(0)]
     public async Task PassAfterDelay(int arg)
     {
@@ -77,7 +77,7 @@ public class UITheoryTests : IDisposable, IAsyncLifetime
         Assert.Equal(0, arg);
     }
 
-    [UITheory, Trait("TestCategory", "FailureExpected")]
+    [DesktopTheory, Trait("TestCategory", "FailureExpected")]
     [InlineData(0)]
     public async Task FailAfterYield(int arg)
     {
@@ -85,7 +85,7 @@ public class UITheoryTests : IDisposable, IAsyncLifetime
         Assert.Equal(1, arg);
     }
 
-    [UITheory, Trait("TestCategory", "FailureExpected")]
+    [DesktopTheory, Trait("TestCategory", "FailureExpected")]
     [InlineData(0)]
     public async Task FailAfterDelay(int arg)
     {
@@ -93,7 +93,7 @@ public class UITheoryTests : IDisposable, IAsyncLifetime
         Assert.Equal(1, arg);
     }
 
-    [UITheory, Trait("TestCategory", "FailureExpected")]
+    [DesktopTheory, Trait("TestCategory", "FailureExpected")]
     [InlineData(0)]
     public async Task FailAfterYield_Task(int arg)
     {
@@ -101,7 +101,7 @@ public class UITheoryTests : IDisposable, IAsyncLifetime
         Assert.Equal(1, arg);
     }
 
-    [UITheory, Trait("TestCategory", "FailureExpected")]
+    [DesktopTheory, Trait("TestCategory", "FailureExpected")]
     [InlineData(0)]
     public async Task FailAfterDelay_Task(int arg)
     {
@@ -109,7 +109,7 @@ public class UITheoryTests : IDisposable, IAsyncLifetime
         Assert.Equal(1, arg);
     }
 
-    [UITheory]
+    [DesktopTheory]
     [InlineData(0)]
     [InlineData(1)]
     public async Task UITheory_OnSingleThreadedSyncContext(int arg)
@@ -123,7 +123,7 @@ public class UITheoryTests : IDisposable, IAsyncLifetime
     }
 
     [Trait("TestCategory", "FailureExpected")]
-    [UITheory]
+    [DesktopTheory]
     [InlineData(1)]
     public async Task UITheoryFails(int arg)
     {
@@ -135,7 +135,7 @@ public class UITheoryTests : IDisposable, IAsyncLifetime
         Assert.False(arg == 0 || arg == 1);
     }
 
-    [UITheory]
+    [DesktopTheory]
     [MemberData(nameof(NonSerializableObject.Data), MemberType = typeof(NonSerializableObject))]
     public void ThreadAffinitizedDataObject(NonSerializableObject o)
     {
@@ -143,7 +143,7 @@ public class UITheoryTests : IDisposable, IAsyncLifetime
         Assert.Equal(Environment.CurrentManagedThreadId, o.ThreadId);
     }
 
-    [UITheory, Trait("TestCategory", "FailureExpected")]
+    [DesktopTheory, Trait("TestCategory", "FailureExpected")]
     [InlineData(0)]
     public void JustFailVoid(int a) => throw new InvalidOperationException("Expected failure " + a);
 
@@ -167,5 +167,13 @@ public class UITheoryTests : IDisposable, IAsyncLifetime
     {
         _ = arg;
         Assert.Fail("Failure expected.");
+    }
+
+    [DesktopTheory(SkipExceptions = [typeof(SkipOnThisException)])]
+    [InlineData(0)]
+    public void CanSkipOnSpecificExceptions(int arg)
+    {
+        _ = arg;
+        throw new SkipOnThisException();
     }
 }

--- a/test/Xunit.StaFact.Tests/WindowsDesktop/WinFormsFactTests.cs
+++ b/test/Xunit.StaFact.Tests/WindowsDesktop/WinFormsFactTests.cs
@@ -85,6 +85,12 @@ public class WinFormsFactTests
         Assert.Fail("Failure expected.");
     }
 
+    [DesktopFact(SkipExceptions = [typeof(SkipOnThisException)])]
+    public void CanSkipOnSpecificExceptions()
+    {
+        throw new SkipOnThisException();
+    }
+
     private void AssertThreadCharacteristics()
     {
         Assert.Same(this.ctorSyncContext, SynchronizationContext.Current);

--- a/test/Xunit.StaFact.Tests/WindowsDesktop/WinFormsTheoryTests.cs
+++ b/test/Xunit.StaFact.Tests/WindowsDesktop/WinFormsTheoryTests.cs
@@ -6,7 +6,7 @@ using DesktopTheoryAttribute = Xunit.WpfTheoryAttribute;
 
 public class WinFormsTheoryTests
 {
-    [WinFormsTheory]
+    [DesktopTheory]
     [InlineData(0)]
     [InlineData(1)]
     public async Task WinFormsTheory_OnSTAThread(int arg)
@@ -20,7 +20,7 @@ public class WinFormsTheoryTests
     }
 
     [Trait("TestCategory", "FailureExpected")]
-    [WinFormsTheory]
+    [DesktopTheory]
     [InlineData(0)]
     [InlineData(1)]
     public async Task WinFormsTheoryFails(int arg)
@@ -33,7 +33,7 @@ public class WinFormsTheoryTests
         Assert.False(arg == 0 || arg == 1);
     }
 
-    [WinFormsTheory]
+    [DesktopTheory]
     [MemberData(nameof(NonSerializableObject.Data), MemberType = typeof(NonSerializableObject))]
     public void ThreadAffinitizedDataObject(NonSerializableObject o)
     {
@@ -41,7 +41,7 @@ public class WinFormsTheoryTests
         Assert.Equal(Environment.CurrentManagedThreadId, o.ThreadId);
     }
 
-    [WinFormsTheory, Trait("TestCategory", "FailureExpected")]
+    [DesktopTheory, Trait("TestCategory", "FailureExpected")]
     [InlineData(0)]
     public void JustFailVoid(int a) => throw new InvalidOperationException("Expected failure " + a);
 
@@ -65,5 +65,13 @@ public class WinFormsTheoryTests
     {
         _ = arg;
         Assert.Fail("Failure expected.");
+    }
+
+    [DesktopTheory(SkipExceptions = [typeof(SkipOnThisException)])]
+    [InlineData(0)]
+    public void CanSkipOnSpecificExceptions(int arg)
+    {
+        _ = arg;
+        throw new SkipOnThisException();
     }
 }

--- a/test/Xunit.StaFact.Tests/WindowsDesktop/WinFormsTheoryTests.cs
+++ b/test/Xunit.StaFact.Tests/WindowsDesktop/WinFormsTheoryTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
-using DesktopTheoryAttribute = Xunit.WpfTheoryAttribute;
+using DesktopTheoryAttribute = Xunit.WinFormsTheoryAttribute;
 
 public class WinFormsTheoryTests
 {

--- a/test/Xunit.StaFact.Tests/WindowsDesktop/WpfFactTests.cs
+++ b/test/Xunit.StaFact.Tests/WindowsDesktop/WpfFactTests.cs
@@ -95,6 +95,12 @@ public class WpfFactTests
         Assert.Fail("Failure expected.");
     }
 
+    [DesktopFact(SkipExceptions = [typeof(SkipOnThisException)])]
+    public void CanSkipOnSpecificExceptions()
+    {
+        throw new SkipOnThisException();
+    }
+
     private void AssertThreadCharacteristics()
     {
         Assert.IsType<DesktopSyncContext>(SynchronizationContext.Current);

--- a/test/Xunit.StaFact.Tests/WindowsDesktop/WpfTheoryTests.cs
+++ b/test/Xunit.StaFact.Tests/WindowsDesktop/WpfTheoryTests.cs
@@ -13,7 +13,7 @@ public class WpfTheoryTests
         new object[] { 3, 4 },
     };
 
-    [WpfTheory]
+    [DesktopTheory]
     [InlineData(0)]
     [InlineData(1)]
     public async Task WpfTheory_OnSTAThread(int arg)
@@ -27,7 +27,7 @@ public class WpfTheoryTests
     }
 
     [Trait("TestCategory", "FailureExpected")]
-    [WpfTheory]
+    [DesktopTheory]
     [InlineData(0)]
     [InlineData(1)]
     public async Task WpfTheoryFails(int arg)
@@ -40,14 +40,14 @@ public class WpfTheoryTests
         Assert.False(arg == 0 || arg == 1);
     }
 
-    [WpfTheory]
+    [DesktopTheory]
     [MemberData(nameof(MemberDataSource))]
     public void MemberBasedTheory(int a, int b)
     {
         Assert.Equal(b, a + 1);
     }
 
-    [WpfTheory, Trait("TestCategory", "FailureExpected")]
+    [DesktopTheory, Trait("TestCategory", "FailureExpected")]
     [InlineData(1)]
     public async Task OperationCanceledException_Thrown(int a)
     {
@@ -56,7 +56,7 @@ public class WpfTheoryTests
         throw new OperationCanceledException();
     }
 
-    [WpfTheory]
+    [DesktopTheory]
     [MemberData(nameof(NonSerializableObject.Data), MemberType = typeof(NonSerializableObject))]
     public void ThreadAffinitizedDataObject(NonSerializableObject o)
     {
@@ -64,7 +64,7 @@ public class WpfTheoryTests
         Assert.Equal(Environment.CurrentManagedThreadId, o.ThreadId);
     }
 
-    [WpfTheory, Trait("TestCategory", "FailureExpected")]
+    [DesktopTheory, Trait("TestCategory", "FailureExpected")]
     [InlineData(0)]
     public void JustFailVoid(int a) => throw new InvalidOperationException("Expected failure " + a);
 
@@ -88,5 +88,13 @@ public class WpfTheoryTests
     {
         _ = arg;
         Assert.Fail("Failure expected.");
+    }
+
+    [DesktopTheory(SkipExceptions = [typeof(SkipOnThisException)])]
+    [InlineData(0)]
+    public void CanSkipOnSpecificExceptions(int arg)
+    {
+        _ = arg;
+        throw new SkipOnThisException();
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0-alpha",
+  "version": "2.1-alpha",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+\\.\\d+$"


### PR DESCRIPTION
Fixes #102 
Closes #132 

This was a simple change. We just needed to pass the `SkipExceptions` property through from the attributes.
