### PR TITLE
Update to xunit.v3 3.x prerelease

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,14 +4,14 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <XunitV3LibraryVersion>2.0.0</XunitV3LibraryVersion>
+    <XunitV3LibraryVersion>3.0.0-pre.25</XunitV3LibraryVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="xunit.analyzers" Version="1.20.0" />
-    <PackageVersion Include="xunit.v3.assert" Version="2.0.0" />
-    <PackageVersion Include="xunit.v3.extensibility.core" Version="2.0.0" />
-    <PackageVersion Include="xunit.v3.runner.inproc.console" Version="2.0.0" />
+    <PackageVersion Include="xunit.analyzers" Version="1.23.0-pre.3" />
+    <PackageVersion Include="xunit.v3.assert" Version="3.0.0-pre.25" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="3.0.0-pre.25" />
+    <PackageVersion Include="xunit.v3.runner.inproc.console" Version="3.0.0-pre.25" />
   </ItemGroup>
   <ItemGroup Condition="'$(MSBuildProjectName)'=='Xunit.StaFact'">
     <PackageVersion Update="xunit.v3.extensibility.core" Version="$(XunitV3LibraryVersion)" />
@@ -19,7 +19,7 @@
   <ItemGroup Label="Library.Template">
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
-    <PackageVersion Include="xunit.v3" Version="2.0.0" />
+    <PackageVersion Include="xunit.v3" Version="3.0.0-pre.25" />
   </ItemGroup>
   <ItemGroup>
     <!-- Put repo-specific GlobalPackageReference items in this group. -->

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "9.0.203",
-    "rollForward": "patch",
+    "rollForward": "latestMinor",
     "allowPrerelease": false
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "9.0.203",
-    "rollForward": "latestMinor",
+    "rollForward": "patch",
     "allowPrerelease": false
   }
 }

--- a/src/Xunit.StaFact/Mac/CocoaFactAttribute.cs
+++ b/src/Xunit.StaFact/Mac/CocoaFactAttribute.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
 using Xunit.Sdk;
 
 namespace Xunit;
@@ -13,4 +14,13 @@ namespace Xunit;
 [XunitTestCaseDiscoverer(typeof(CocoaFactDiscoverer))]
 public class CocoaFactAttribute : FactAttribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CocoaFactAttribute"/> class.
+    /// </summary>
+    public CocoaFactAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
+    {
+    }
 }

--- a/src/Xunit.StaFact/Mac/CocoaTheoryAttribute.cs
+++ b/src/Xunit.StaFact/Mac/CocoaTheoryAttribute.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
 using Xunit.Sdk;
 
 namespace Xunit;
@@ -13,4 +14,13 @@ namespace Xunit;
 [XunitTestCaseDiscoverer(typeof(CocoaTheoryDiscoverer))]
 public class CocoaTheoryAttribute : TheoryAttribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CocoaTheoryAttribute"/> class.
+    /// </summary>
+    public CocoaTheoryAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
+    {
+    }
 }

--- a/src/Xunit.StaFact/Sdk/Utilities.cs
+++ b/src/Xunit.StaFact/Sdk/Utilities.cs
@@ -15,7 +15,7 @@ internal static class Utilities
         IXunitTestMethod testMethod,
         IFactAttribute factAttribute)
     {
-        (string TestCaseDisplayName, bool Explicit, Type[]? SkipExceptions, string? SkipReason, Type? SkipType, string? SkipUnless, string? SkipWhen, int Timeout, string UniqueID, IXunitTestMethod ResolvedTestMethod) details;
+        (string TestCaseDisplayName, bool Explicit, Type[]? SkipExceptions, string? SkipReason, Type? SkipType, string? SkipUnless, string? SkipWhen, string? SourceFilePath, int? SourceLineNumber, int Timeout, string UniqueID, IXunitTestMethod ResolvedTestMethod) details;
         Dictionary<string, HashSet<string>> traits;
 
         details = TestIntrospectionHelper.GetTestCaseDetails(discoveryOptions, testMethod, factAttribute);
@@ -29,7 +29,9 @@ internal static class Utilities
                details.UniqueID,
                details.Explicit,
                skipReason,
-               traits);
+               traits,
+               sourceFilePath: details.SourceFilePath,
+               sourceLineNumber: details.SourceLineNumber);
         }
 
         return new UITestCase(
@@ -45,6 +47,8 @@ internal static class Utilities
             details.SkipUnless,
             details.SkipWhen,
             traits,
+            sourceFilePath: details.SourceFilePath,
+            sourceLineNumber: details.SourceLineNumber,
             timeout: details.Timeout);
     }
 
@@ -57,7 +61,7 @@ internal static class Utilities
         ITheoryDataRow dataRow,
         object?[] testMethodArguments)
     {
-        (string TestCaseDisplayName, bool Explicit, Type[]? SkipExceptions, string? SkipReason, Type? SkipType, string? SkipUnless, string? SkipWhen, int Timeout, string UniqueID, IXunitTestMethod ResolvedTestMethod) details;
+        (string TestCaseDisplayName, bool Explicit, Type[]? SkipExceptions, string? SkipReason, Type? SkipType, string? SkipUnless, string? SkipWhen, string? SourceFilePath, int? SourceLineNumber, int Timeout, string UniqueID, IXunitTestMethod ResolvedTestMethod) details;
         Dictionary<string, HashSet<string>> traits;
 
         details = TestIntrospectionHelper.GetTestCaseDetailsForTheoryDataRow(discoveryOptions, testMethod, theoryAttribute, dataRow, testMethodArguments);
@@ -72,7 +76,9 @@ internal static class Utilities
                details.Explicit,
                skipReason,
                traits,
-               testMethodArguments);
+               testMethodArguments,
+               sourceFilePath: details.SourceFilePath,
+               sourceLineNumber: details.SourceLineNumber);
         }
 
         return new UITestCase(
@@ -89,6 +95,8 @@ internal static class Utilities
             details.SkipWhen,
             traits,
             testMethodArguments,
+            sourceFilePath: details.SourceFilePath,
+            sourceLineNumber: details.SourceLineNumber,
             timeout: details.Timeout);
     }
 
@@ -99,7 +107,7 @@ internal static class Utilities
         IXunitTestMethod testMethod,
         ITheoryAttribute attribute)
     {
-        (string TestCaseDisplayName, bool Explicit, Type[]? SkipExceptions, string? SkipReason, Type? SkipType, string? SkipUnless, string? SkipWhen, int Timeout, string UniqueID, IXunitTestMethod ResolvedTestMethod) details;
+        (string TestCaseDisplayName, bool Explicit, Type[]? SkipExceptions, string? SkipReason, Type? SkipType, string? SkipUnless, string? SkipWhen, string? SourceFilePath, int? SourceLineNumber, int Timeout, string UniqueID, IXunitTestMethod ResolvedTestMethod) details;
         Dictionary<string, HashSet<string>> traits;
 
         details = TestIntrospectionHelper.GetTestCaseDetails(discoveryOptions, testMethod, attribute);
@@ -113,7 +121,9 @@ internal static class Utilities
                details.UniqueID,
                details.Explicit,
                skipReason,
-               traits);
+               traits,
+               sourceFilePath: details.SourceFilePath,
+               sourceLineNumber: details.SourceLineNumber);
         }
 
         return new UIDelayEnumeratedTestCase(
@@ -130,6 +140,8 @@ internal static class Utilities
             details.SkipUnless,
             details.SkipWhen,
             traits,
+            sourceFilePath: details.SourceFilePath,
+            sourceLineNumber: details.SourceLineNumber,
             timeout: details.Timeout);
     }
 

--- a/src/Xunit.StaFact/StaFactAttribute.cs
+++ b/src/Xunit.StaFact/StaFactAttribute.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
 using Xunit.Sdk;
 
 namespace Xunit;
@@ -18,4 +19,13 @@ namespace Xunit;
 [XunitTestCaseDiscoverer(typeof(StaFactDiscoverer))]
 public class StaFactAttribute : FactAttribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StaFactAttribute"/> class.
+    /// </summary>
+    public StaFactAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
+    {
+    }
 }

--- a/src/Xunit.StaFact/StaTheoryAttribute.cs
+++ b/src/Xunit.StaFact/StaTheoryAttribute.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
 using Xunit.Sdk;
 
 namespace Xunit;
@@ -18,4 +19,13 @@ namespace Xunit;
 [XunitTestCaseDiscoverer(typeof(StaTheoryDiscoverer))]
 public class StaTheoryAttribute : TheoryAttribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StaTheoryAttribute"/> class.
+    /// </summary>
+    public StaTheoryAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
+    {
+    }
 }

--- a/src/Xunit.StaFact/UIFactAttribute.cs
+++ b/src/Xunit.StaFact/UIFactAttribute.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
 using Xunit.Sdk;
 
 namespace Xunit;
@@ -14,4 +15,13 @@ namespace Xunit;
 [XunitTestCaseDiscoverer(typeof(UIFactDiscoverer))]
 public class UIFactAttribute : FactAttribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UIFactAttribute"/> class.
+    /// </summary>
+    public UIFactAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
+    {
+    }
 }

--- a/src/Xunit.StaFact/UITheoryAttribute.cs
+++ b/src/Xunit.StaFact/UITheoryAttribute.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
 using Xunit.Sdk;
 
 namespace Xunit;
@@ -14,4 +15,13 @@ namespace Xunit;
 [XunitTestCaseDiscoverer(typeof(UITheoryDiscoverer))]
 public class UITheoryAttribute : TheoryAttribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UITheoryAttribute"/> class.
+    /// </summary>
+    public UITheoryAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
+    {
+    }
 }

--- a/src/Xunit.StaFact/WindowsDesktop/WinFormsFactAttribute.cs
+++ b/src/Xunit.StaFact/WindowsDesktop/WinFormsFactAttribute.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
 using Xunit.Sdk;
 
 namespace Xunit;
@@ -14,4 +15,13 @@ namespace Xunit;
 [XunitTestCaseDiscoverer(typeof(WinFormsFactDiscoverer))]
 public class WinFormsFactAttribute : FactAttribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WinFormsFactAttribute"/> class.
+    /// </summary>
+    public WinFormsFactAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
+    {
+    }
 }

--- a/src/Xunit.StaFact/WindowsDesktop/WinFormsTheoryAttribute.cs
+++ b/src/Xunit.StaFact/WindowsDesktop/WinFormsTheoryAttribute.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
 using Xunit.Sdk;
 
 namespace Xunit;
@@ -14,4 +15,13 @@ namespace Xunit;
 [XunitTestCaseDiscoverer(typeof(WinFormsTheoryDiscoverer))]
 public class WinFormsTheoryAttribute : TheoryAttribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WinFormsTheoryAttribute"/> class.
+    /// </summary>
+    public WinFormsTheoryAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
+    {
+    }
 }

--- a/src/Xunit.StaFact/WindowsDesktop/WpfFactAttribute.cs
+++ b/src/Xunit.StaFact/WindowsDesktop/WpfFactAttribute.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
 using System.Windows.Threading;
 using Xunit.Sdk;
 
@@ -15,4 +16,13 @@ namespace Xunit;
 [XunitTestCaseDiscoverer(typeof(WpfFactDiscoverer))]
 public class WpfFactAttribute : FactAttribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WpfFactAttribute"/> class.
+    /// </summary>
+    public WpfFactAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
+    {
+    }
 }

--- a/src/Xunit.StaFact/WindowsDesktop/WpfTheoryAttribute.cs
+++ b/src/Xunit.StaFact/WindowsDesktop/WpfTheoryAttribute.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
 using System.Windows.Threading;
 using Xunit.Sdk;
 
@@ -15,4 +16,13 @@ namespace Xunit;
 [XunitTestCaseDiscoverer(typeof(WpfTheoryDiscoverer))]
 public class WpfTheoryAttribute : TheoryAttribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WpfTheoryAttribute"/> class.
+    /// </summary>
+    public WpfTheoryAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
+    {
+    }
 }

--- a/src/Xunit.StaFact/net472/PublicAPI.Unshipped.txt
+++ b/src/Xunit.StaFact/net472/PublicAPI.Unshipped.txt
@@ -1,4 +1,12 @@
+Xunit.StaFactAttribute.StaFactAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
+Xunit.StaTheoryAttribute.StaTheoryAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
+Xunit.UIFactAttribute.UIFactAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
 Xunit.UISettingsAttribute
 Xunit.UISettingsAttribute.MaxAttempts.get -> int
 Xunit.UISettingsAttribute.MaxAttempts.set -> void
 Xunit.UISettingsAttribute.UISettingsAttribute() -> void
+Xunit.UITheoryAttribute.UITheoryAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
+Xunit.WinFormsFactAttribute.WinFormsFactAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
+Xunit.WinFormsTheoryAttribute.WinFormsTheoryAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
+Xunit.WpfFactAttribute.WpfFactAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
+Xunit.WpfTheoryAttribute.WpfTheoryAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void

--- a/src/Xunit.StaFact/net472/PublicAPI.Unshipped.txt
+++ b/src/Xunit.StaFact/net472/PublicAPI.Unshipped.txt
@@ -10,3 +10,11 @@ Xunit.WinFormsFactAttribute.WinFormsFactAttribute(string? sourceFilePath = null,
 Xunit.WinFormsTheoryAttribute.WinFormsTheoryAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
 Xunit.WpfFactAttribute.WpfFactAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
 Xunit.WpfTheoryAttribute.WpfTheoryAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
+*REMOVED*Xunit.StaFactAttribute.StaFactAttribute() -> void
+*REMOVED*Xunit.StaTheoryAttribute.StaTheoryAttribute() -> void
+*REMOVED*Xunit.UIFactAttribute.UIFactAttribute() -> void
+*REMOVED*Xunit.UITheoryAttribute.UITheoryAttribute() -> void
+*REMOVED*Xunit.WinFormsFactAttribute.WinFormsFactAttribute() -> void
+*REMOVED*Xunit.WinFormsTheoryAttribute.WinFormsTheoryAttribute() -> void
+*REMOVED*Xunit.WpfFactAttribute.WpfFactAttribute() -> void
+*REMOVED*Xunit.WpfTheoryAttribute.WpfTheoryAttribute() -> void

--- a/src/Xunit.StaFact/net8.0-macos14.0/PublicAPI.Unshipped.txt
+++ b/src/Xunit.StaFact/net8.0-macos14.0/PublicAPI.Unshipped.txt
@@ -15,9 +15,9 @@ override Xunit.Sdk.UITheoryDiscoverer.CreateTestCasesForDataRow(Xunit.Sdk.ITestF
 override Xunit.Sdk.UITheoryDiscoverer.CreateTestCasesForTheory(Xunit.Sdk.ITestFrameworkDiscoveryOptions! discoveryOptions, Xunit.v3.IXunitTestMethod! testMethod, Xunit.v3.ITheoryAttribute! theoryAttribute) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyCollection<Xunit.v3.IXunitTestCase!>!>
 static Xunit.Sdk.UITestRunner.Instance.get -> Xunit.Sdk.UITestRunner!
 Xunit.CocoaFactAttribute
-Xunit.CocoaFactAttribute.CocoaFactAttribute() -> void
+Xunit.CocoaFactAttribute.CocoaFactAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
 Xunit.CocoaTheoryAttribute
-Xunit.CocoaTheoryAttribute.CocoaTheoryAttribute() -> void
+Xunit.CocoaTheoryAttribute.CocoaTheoryAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
 Xunit.Sdk.CocoaFactDiscoverer
 Xunit.Sdk.CocoaFactDiscoverer.CocoaFactDiscoverer() -> void
 Xunit.Sdk.CocoaTheoryDiscoverer
@@ -51,14 +51,14 @@ Xunit.Sdk.UITestRunnerContext.Settings.get -> Xunit.UISettingsAttribute!
 Xunit.Sdk.UITheoryDiscoverer
 Xunit.Sdk.UITheoryDiscoverer.UITheoryDiscoverer() -> void
 Xunit.StaFactAttribute
-Xunit.StaFactAttribute.StaFactAttribute() -> void
+Xunit.StaFactAttribute.StaFactAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
 Xunit.StaTheoryAttribute
-Xunit.StaTheoryAttribute.StaTheoryAttribute() -> void
+Xunit.StaTheoryAttribute.StaTheoryAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
 Xunit.UIFactAttribute
-Xunit.UIFactAttribute.UIFactAttribute() -> void
+Xunit.UIFactAttribute.UIFactAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
 Xunit.UISettingsAttribute
 Xunit.UISettingsAttribute.MaxAttempts.get -> int
 Xunit.UISettingsAttribute.MaxAttempts.set -> void
 Xunit.UISettingsAttribute.UISettingsAttribute() -> void
 Xunit.UITheoryAttribute
-Xunit.UITheoryAttribute.UITheoryAttribute() -> void
+Xunit.UITheoryAttribute.UITheoryAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void

--- a/src/Xunit.StaFact/net8.0-windows/PublicAPI.Unshipped.txt
+++ b/src/Xunit.StaFact/net8.0-windows/PublicAPI.Unshipped.txt
@@ -54,22 +54,22 @@ Xunit.Sdk.WpfFactDiscoverer.WpfFactDiscoverer() -> void
 Xunit.Sdk.WpfTheoryDiscoverer
 Xunit.Sdk.WpfTheoryDiscoverer.WpfTheoryDiscoverer() -> void
 Xunit.StaFactAttribute
-Xunit.StaFactAttribute.StaFactAttribute() -> void
+Xunit.StaFactAttribute.StaFactAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
 Xunit.StaTheoryAttribute
-Xunit.StaTheoryAttribute.StaTheoryAttribute() -> void
+Xunit.StaTheoryAttribute.StaTheoryAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
 Xunit.UIFactAttribute
-Xunit.UIFactAttribute.UIFactAttribute() -> void
+Xunit.UIFactAttribute.UIFactAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
 Xunit.UISettingsAttribute
 Xunit.UISettingsAttribute.MaxAttempts.get -> int
 Xunit.UISettingsAttribute.MaxAttempts.set -> void
 Xunit.UISettingsAttribute.UISettingsAttribute() -> void
 Xunit.UITheoryAttribute
-Xunit.UITheoryAttribute.UITheoryAttribute() -> void
+Xunit.UITheoryAttribute.UITheoryAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
 Xunit.WinFormsFactAttribute
-Xunit.WinFormsFactAttribute.WinFormsFactAttribute() -> void
+Xunit.WinFormsFactAttribute.WinFormsFactAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
 Xunit.WinFormsTheoryAttribute
-Xunit.WinFormsTheoryAttribute.WinFormsTheoryAttribute() -> void
+Xunit.WinFormsTheoryAttribute.WinFormsTheoryAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
 Xunit.WpfFactAttribute
-Xunit.WpfFactAttribute.WpfFactAttribute() -> void
+Xunit.WpfFactAttribute.WpfFactAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
 Xunit.WpfTheoryAttribute
-Xunit.WpfTheoryAttribute.WpfTheoryAttribute() -> void
+Xunit.WpfTheoryAttribute.WpfTheoryAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void

--- a/src/Xunit.StaFact/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Xunit.StaFact/net8.0/PublicAPI.Unshipped.txt
@@ -2,3 +2,11 @@ Xunit.UISettingsAttribute
 Xunit.UISettingsAttribute.MaxAttempts.get -> int
 Xunit.UISettingsAttribute.MaxAttempts.set -> void
 Xunit.UISettingsAttribute.UISettingsAttribute() -> void
+Xunit.UITheoryAttribute.UITheoryAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
+Xunit.StaFactAttribute.StaFactAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
+Xunit.StaTheoryAttribute.StaTheoryAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
+Xunit.UIFactAttribute.UIFactAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
+*REMOVED*Xunit.StaFactAttribute.StaFactAttribute() -> void
+*REMOVED*Xunit.StaTheoryAttribute.StaTheoryAttribute() -> void
+*REMOVED*Xunit.UIFactAttribute.UIFactAttribute() -> void
+*REMOVED*Xunit.UITheoryAttribute.UITheoryAttribute() -> void

--- a/src/Xunit.StaFact/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Xunit.StaFact/netstandard2.0/PublicAPI.Unshipped.txt
@@ -38,14 +38,14 @@ Xunit.Sdk.UITestRunnerContext.Settings.get -> Xunit.UISettingsAttribute!
 Xunit.Sdk.UITheoryDiscoverer
 Xunit.Sdk.UITheoryDiscoverer.UITheoryDiscoverer() -> void
 Xunit.StaFactAttribute
-Xunit.StaFactAttribute.StaFactAttribute() -> void
+Xunit.StaFactAttribute.StaFactAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
 Xunit.StaTheoryAttribute
-Xunit.StaTheoryAttribute.StaTheoryAttribute() -> void
+Xunit.StaTheoryAttribute.StaTheoryAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
 Xunit.UIFactAttribute
-Xunit.UIFactAttribute.UIFactAttribute() -> void
+Xunit.UIFactAttribute.UIFactAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void
 Xunit.UISettingsAttribute
 Xunit.UISettingsAttribute.MaxAttempts.get -> int
 Xunit.UISettingsAttribute.MaxAttempts.set -> void
 Xunit.UISettingsAttribute.UISettingsAttribute() -> void
 Xunit.UITheoryAttribute
-Xunit.UITheoryAttribute.UITheoryAttribute() -> void
+Xunit.UITheoryAttribute.UITheoryAttribute(string? sourceFilePath = null, int sourceLineNumber = -1) -> void

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.1",
+  "version": "3.0-alpha",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+\\.\\d+$"


### PR DESCRIPTION
Fixes #147

NOTE: I noticed you have some APIs in PublicAPI.Unshipped.txt but they are actually shipped and should have been moved to shipped. I left that in place. So, for the constructors that changed their signature, if originally was in Unshipped, I updated in place. And if it was originally in Shipped, I added to Unshipped with `*REMOVED*` prefix and added the new API.