### PR TITLE
Fix macOS build environment corruption

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "nbgv": {
-      "version": "3.10.91",
+      "version": "3.11.96-beta",
       "commands": [
         "nbgv"
       ],

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,7 @@
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.2.19" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <!-- The condition works around https://github.com/dotnet/sdk/issues/44951 -->
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.10.91" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.11.96-beta" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
     <GlobalPackageReference Include="PolySharp" Version="1.16.0" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>


### PR DESCRIPTION
The macOS build completes successfully but intermittently fails when GitHub Actions parses a corrupted `GITHUB_ENV` file. Nerdbank.GitVersioning 3.10.91 performs unsynchronized concurrent appends on non-Windows platforms, which tore the package version `4.0.21` into an invalid `.0.21` record in [the failing run](https://github.com/AArnott/Xunit.StaFact/actions/runs/32741286228/job/97476104887).

Upgrade both the MSBuild package and matching `nbgv` tool to 3.11.96-beta. This release includes the upstream fix that serializes concurrent environment-file writes across MSBuild processes.

The CI build/pack command produces a valid GitHub environment file, and the CI-filtered test suite passes all 532 tests.