### PR TITLE
Add shared UI thread fixtures

### DIFF
--- a/docfx/docs/features.md
+++ b/docfx/docs/features.md
@@ -13,6 +13,71 @@ Xunit test attributes            | Supported OS's   | SynchronizationContext    
 We also offer a @Xunit.UISettingsAttribute that can be applied to individual test methods or test classes to control the behavior of the various UI test attributes.
 This attribute offers a means to add automated retries to a test's execution for unstable tests.
 
+## Shared UI thread fixtures
+
+By default, every fact or theory in this package runs on a newly created thread that is disposed when that test finishes.
+This avoids sharing thread-affine state and allows unrelated tests to run concurrently.
+
+Some UI frameworks retain thread-affine objects in static caches, or a suite may intentionally host an application-level
+object for several tests. In those cases, opt in to a shared thread with an xUnit class or collection fixture.
+The fixture owns the thread, and its xUnit lifetime determines how long the thread is shared.
+
+Test attribute | Compatible fixture
+|---|---|
+@Xunit.UIFactAttribute, @Xunit.UITheoryAttribute | @Xunit.UIThreadFixture
+@Xunit.StaFactAttribute, @Xunit.StaTheoryAttribute | @Xunit.StaThreadFixture
+@Xunit.WpfFactAttribute, @Xunit.WpfTheoryAttribute | @Xunit.WpfThreadFixture
+@Xunit.WinFormsFactAttribute, @Xunit.WinFormsTheoryAttribute | @Xunit.WinFormsThreadFixture
+@Xunit.CocoaFactAttribute, @Xunit.CocoaTheoryAttribute | @Xunit.CocoaThreadFixture
+
+### Class scope
+
+Implement `IClassFixture<TFixture>` and receive that fixture in the test class constructor.
+All compatible UI facts and theories in the class then execute on the fixture's thread.
+
+[!code-csharp[](../../samples/SharedThreadSamples.cs#ClassSharedThread)]
+
+The fixture must be present in the constructor arguments so the test runner can identify it.
+Merely declaring `IClassFixture<TFixture>` without receiving the fixture does not opt the tests into its thread.
+
+### Collection scope
+
+Use an `ICollectionFixture<TFixture>` when multiple test classes must share the same thread.
+Each participating class must belong to that collection and receive the collection fixture in its constructor.
+
+[!code-csharp[](../../samples/SharedThreadSamples.cs#CollectionSharedThread)]
+
+xUnit does not run tests in one collection concurrently, so tests borrowing one collection fixture do not overlap.
+Classes using different fixture instances remain eligible for parallel execution. The xUnit execution throttle remains
+in effect while a test is running on a fixture thread.
+
+### Fixture initialization and cleanup
+
+xUnit constructs fixtures on its own worker thread, before `Xunit.StaFact` participates in test execution.
+Consequently, a fixture's CLR constructor is **not** guaranteed to run on an STA or UI thread.
+
+The simplest usage requires no custom fixture type: register and inject one of the library-provided fixtures directly,
+as shown in the class and collection examples above.
+
+For thread-affine setup and cleanup, derive from the compatible fixture type and override
+`InitializeOnUIThreadAsync` and `DisposeOnUIThreadAsync`. These hooks are dispatched to the owned thread,
+and cleanup runs before that thread is shut down.
+
+[!code-csharp[](../../samples/SharedThreadSamples.cs#SharedThreadFixture)]
+
+The portable UI, WPF, WinForms, and Cocoa fixtures install their corresponding synchronization context.
+The STA fixture intentionally does not install one, matching @Xunit.StaFactAttribute behavior; after a yielding
+`await`, code may resume on a thread-pool thread.
+
+### Compatibility and ownership rules
+
+- A test class may receive at most one @Xunit.UIThreadFixtureBase-derived fixture.
+- The fixture must match the fact or theory attribute. For example, a @Xunit.WpfFactAttribute cannot borrow an
+  @Xunit.UIThreadFixture.
+- Tests that do not receive a shared-thread fixture retain the default fresh-thread-per-test behavior.
+- Do not dispose a fixture directly when xUnit owns it. xUnit disposes it at the end of its class or collection lifetime.
+- Put only state that is intentionally shared into the fixture. Test class instances are still created separately for each test.
+
 
 [^1]: This is a private @System.Threading.SynchronizationContext that works cross-platform and effectively keeps code running on the test's starting thread the way a GUI application's main thread would do.
 

--- a/docfx/docs/getting-started.md
+++ b/docfx/docs/getting-started.md
@@ -39,3 +39,13 @@ Applicable only on Windows.
 Because no @System.Threading.SynchronizationContext is applied by default, an async test will resume on a threadpool thread instead of the test thread after a yielding await.
 
 [!code-csharp[](../../samples/SampleTests.cs#STAFact)]
+
+## Sharing a UI thread between tests
+
+By default, each UI fact or theory gets a fresh thread. When thread-affine state must outlive one test,
+register a shared-thread fixture and receive it in the test class constructor:
+
+[!code-csharp[](../../samples/SharedThreadSamples.cs#ClassSharedThread)]
+
+See [Shared UI thread fixtures](features.md#shared-ui-thread-fixtures) for collection scope,
+fixture lifecycle hooks, supported fixture types, and concurrency behavior.

--- a/samples/SharedThreadSamples.cs
+++ b/samples/SharedThreadSamples.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+/// <summary>
+/// Demonstrates sharing one UI thread across several tests.
+/// </summary>
+public static class SharedThreadSamples
+{
+    #region ClassSharedThread
+    /// <summary>
+    /// Every UI fact or theory in this class uses one shared thread.
+    /// </summary>
+    public class ClassScopedTests : IClassFixture<UIThreadFixture>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClassScopedTests"/> class.
+        /// </summary>
+        /// <param name="fixture">The shared thread fixture.</param>
+        public ClassScopedTests(UIThreadFixture fixture)
+        {
+        }
+
+        /// <summary>
+        /// Runs on the shared thread.
+        /// </summary>
+        [UIFact]
+        public void FirstTest()
+        {
+            Assert.NotNull(SynchronizationContext.Current);
+        }
+
+        /// <summary>
+        /// Runs on the same thread as <see cref="FirstTest"/>.
+        /// </summary>
+        [UIFact]
+        public void SecondTest()
+        {
+            Assert.NotNull(SynchronizationContext.Current);
+        }
+    }
+    #endregion
+
+    #region CollectionSharedThread
+    /// <summary>
+    /// Defines a collection whose test classes share one UI thread.
+    /// </summary>
+    [CollectionDefinition(nameof(SharedUIThreadCollection))]
+    public class SharedUIThreadCollection : ICollectionFixture<UIThreadFixture>
+    {
+    }
+
+    /// <summary>
+    /// Tests in any class in this collection can use the same fixture thread.
+    /// </summary>
+    [Collection(nameof(SharedUIThreadCollection))]
+    public class CollectionScopedTests
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CollectionScopedTests"/> class.
+        /// </summary>
+        /// <param name="fixture">The collection's shared thread fixture.</param>
+        public CollectionScopedTests(UIThreadFixture fixture)
+        {
+        }
+
+        /// <summary>
+        /// Runs on the collection fixture thread.
+        /// </summary>
+        [UIFact]
+        public void UsesCollectionThread()
+        {
+            Assert.NotNull(SynchronizationContext.Current);
+        }
+    }
+    #endregion
+
+    #region SharedThreadFixture
+    /// <summary>
+    /// Owns thread-affine state and initializes and disposes it on the shared UI thread.
+    /// </summary>
+    public class ThreadAffineFixture : UIThreadFixture
+    {
+        /// <summary>
+        /// Gets the thread that owns the fixture state.
+        /// </summary>
+        public int ThreadId { get; private set; }
+
+        /// <inheritdoc/>
+        protected override ValueTask InitializeOnUIThreadAsync()
+        {
+            this.ThreadId = Environment.CurrentManagedThreadId;
+            return default;
+        }
+
+        /// <inheritdoc/>
+        protected override ValueTask DisposeOnUIThreadAsync()
+        {
+            Assert.Equal(this.ThreadId, Environment.CurrentManagedThreadId);
+            return default;
+        }
+    }
+    #endregion
+}

--- a/src/Xunit.StaFact/Mac/CocoaThreadFixture.cs
+++ b/src/Xunit.StaFact/Mac/CocoaThreadFixture.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+using Xunit.Sdk;
+
+namespace Xunit;
+
+/// <summary>
+/// Provides a shared Cocoa UI thread for <see cref="CocoaFactAttribute"/> and <see cref="CocoaTheoryAttribute"/> tests.
+/// </summary>
+public class CocoaThreadFixture : UIThreadFixtureBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CocoaThreadFixture"/> class.
+    /// </summary>
+    public CocoaThreadFixture()
+        : base(UITestCase.SyncContextType.Cocoa)
+    {
+    }
+}

--- a/src/Xunit.StaFact/Sdk/ThreadRental.cs
+++ b/src/Xunit.StaFact/Sdk/ThreadRental.cs
@@ -57,8 +57,8 @@ internal class ThreadRental : IDisposable
 
     internal static async Task<ThreadRental> CreateAsync(SyncContextAdapter syncContextAdapter, string threadName)
     {
-        var disposalTaskSource = new TaskCompletionSource<object?>();
-        var syncContextSource = new TaskCompletionSource<SynchronizationContext>();
+        var disposalTaskSource = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var syncContextSource = new TaskCompletionSource<SynchronizationContext>(TaskCreationOptions.RunContinuationsAsynchronously);
         var thread = new Thread(() =>
         {
             SynchronizationContext uiSyncContext;

--- a/src/Xunit.StaFact/Sdk/ThreadRental.cs
+++ b/src/Xunit.StaFact/Sdk/ThreadRental.cs
@@ -9,6 +9,7 @@ internal class ThreadRental : IDisposable
 {
     private readonly TaskCompletionSource<object?> disposalTaskSource;
     private readonly SynchronizationContext syncContext;
+    private int disposing;
 
     private ThreadRental(SyncContextAdapter syncContextAdapter, TaskCompletionSource<object?> disposalTaskSource, SynchronizationContext uiSyncContextSource)
     {
@@ -36,24 +37,47 @@ internal class ThreadRental : IDisposable
 
     public void Dispose()
     {
-        this.SyncContextAdapter.Cleanup();
-        this.disposalTaskSource.TrySetResult(null);
+        if (Interlocked.Exchange(ref this.disposing, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            this.syncContext.Send(_ => this.SyncContextAdapter.Cleanup(), null);
+        }
+        finally
+        {
+            this.disposalTaskSource.TrySetResult(null);
+        }
     }
 
     internal static async Task<ThreadRental> CreateAsync(SyncContextAdapter syncContextAdapter, ITestMethod testMethod)
+        => await CreateAsync(syncContextAdapter, $"{testMethod.TestClass.TestClassName}.{testMethod.MethodName}");
+
+    internal static async Task<ThreadRental> CreateAsync(SyncContextAdapter syncContextAdapter, string threadName)
     {
         var disposalTaskSource = new TaskCompletionSource<object?>();
         var syncContextSource = new TaskCompletionSource<SynchronizationContext>();
-        var threadName = $"{testMethod.TestClass.TestClassName}.{testMethod.MethodName}";
         var thread = new Thread(() =>
         {
-            SynchronizationContext uiSyncContext = syncContextAdapter.Create(threadName);
-            if (syncContextAdapter.ShouldSetAsCurrent)
+            SynchronizationContext uiSyncContext;
+            try
             {
-                SynchronizationContext.SetSynchronizationContext(uiSyncContext);
+                uiSyncContext = syncContextAdapter.Create(threadName);
+                if (syncContextAdapter.ShouldSetAsCurrent)
+                {
+                    SynchronizationContext.SetSynchronizationContext(uiSyncContext);
+                }
+
+                syncContextAdapter.InitializeThread();
+            }
+            catch (Exception ex)
+            {
+                syncContextSource.TrySetException(ex);
+                return;
             }
 
-            syncContextAdapter.InitializeThread();
             syncContextSource.SetResult(uiSyncContext);
             syncContextAdapter.PumpTill(uiSyncContext, disposalTaskSource.Task);
         });

--- a/src/Xunit.StaFact/Sdk/UITestCaseRunner.cs
+++ b/src/Xunit.StaFact/Sdk/UITestCaseRunner.cs
@@ -105,21 +105,31 @@ public class UITestCaseRunner : XunitTestCaseRunnerBase<UITestCaseRunnerContext,
         Task<RunSummary> task = Task.Run(
             async () =>
             {
-                using ThreadRental threadRental = await ThreadRental.CreateAsync(adapter, testCase.TestMethod);
-                await threadRental.SynchronizationContext;
-                var runner = new UITestCaseRunner(settings, threadRental);
-                return await runner.Run(
-                    testCase,
-                    messageBus,
-                    aggregator,
-                    cancellationTokenSource,
-                    testCase.TestCaseDisplayName,
-                    testCase.SkipReason,
-                    explicitOption,
-                    constructorArguments,
-                    parallelMode,
-                    scheduler,
-                    methodFixtureMappings);
+                UIThreadFixtureBase? sharedThreadFixture = GetSharedThreadFixture(constructorArguments, adapter);
+                ThreadRental? ownedThreadRental = null;
+                try
+                {
+                    ThreadRental threadRental = sharedThreadFixture?.ThreadRental
+                        ?? (ownedThreadRental = await ThreadRental.CreateAsync(adapter, testCase.TestMethod));
+                    await threadRental.SynchronizationContext;
+                    var runner = new UITestCaseRunner(settings, threadRental);
+                    return await runner.Run(
+                        testCase,
+                        messageBus,
+                        aggregator,
+                        cancellationTokenSource,
+                        testCase.TestCaseDisplayName,
+                        testCase.SkipReason,
+                        explicitOption,
+                        constructorArguments,
+                        parallelMode,
+                        scheduler,
+                        methodFixtureMappings);
+                }
+                finally
+                {
+                    ownedThreadRental?.Dispose();
+                }
             },
             cancellationTokenSource.Token);
 
@@ -160,6 +170,24 @@ public class UITestCaseRunner : XunitTestCaseRunnerBase<UITestCaseRunnerContext,
         }
 
         return result;
+    }
+
+    private static UIThreadFixtureBase? GetSharedThreadFixture(object?[] constructorArguments, SyncContextAdapter adapter)
+    {
+        UIThreadFixtureBase[] sharedThreadFixtures = constructorArguments.OfType<UIThreadFixtureBase>().ToArray();
+        UIThreadFixtureBase? sharedThreadFixture = sharedThreadFixtures.FirstOrDefault();
+        if (sharedThreadFixtures.Any(fixture => !ReferenceEquals(fixture, sharedThreadFixture)))
+        {
+            throw new InvalidOperationException("A UI test class may receive only one shared UI thread fixture.");
+        }
+
+        if (sharedThreadFixture is not null && !ReferenceEquals(sharedThreadFixture.SyncContextAdapter, adapter))
+        {
+            throw new InvalidOperationException(
+                $"The {sharedThreadFixture.GetType().FullName} fixture is not compatible with this test's synchronization context.");
+        }
+
+        return sharedThreadFixture;
     }
 
     private sealed class FilteringMessageBus : IMessageBus

--- a/src/Xunit.StaFact/StaThreadFixture.cs
+++ b/src/Xunit.StaFact/StaThreadFixture.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+using Xunit.Sdk;
+
+namespace Xunit;
+
+/// <summary>
+/// Provides a shared STA thread for <see cref="StaFactAttribute"/> and <see cref="StaTheoryAttribute"/> tests.
+/// </summary>
+/// <remarks>
+/// This fixture does not install a synchronization context. Code after a yielding <see langword="await"/>
+/// may resume on a thread-pool thread.
+/// </remarks>
+public class StaThreadFixture : UIThreadFixtureBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StaThreadFixture"/> class.
+    /// </summary>
+    public StaThreadFixture()
+        : base(UITestCase.SyncContextType.None)
+    {
+    }
+}

--- a/src/Xunit.StaFact/UIThreadFixture.cs
+++ b/src/Xunit.StaFact/UIThreadFixture.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+using Xunit.Sdk;
+
+namespace Xunit;
+
+/// <summary>
+/// Provides a shared portable UI thread for <see cref="UIFactAttribute"/> and <see cref="UITheoryAttribute"/> tests.
+/// </summary>
+public class UIThreadFixture : UIThreadFixtureBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UIThreadFixture"/> class.
+    /// </summary>
+    public UIThreadFixture()
+        : base(UITestCase.SyncContextType.Portable)
+    {
+    }
+}

--- a/src/Xunit.StaFact/UIThreadFixtureBase.cs
+++ b/src/Xunit.StaFact/UIThreadFixtureBase.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+using Xunit.Sdk;
+
+namespace Xunit;
+
+/// <summary>
+/// Provides a shared UI thread for tests in an xUnit class or collection fixture.
+/// </summary>
+/// <remarks>
+/// Derive from one of the concrete fixture types rather than deriving from this type directly.
+/// </remarks>
+public abstract class UIThreadFixtureBase : IAsyncLifetime
+{
+    private readonly string threadName;
+    private ThreadRental? threadRental;
+
+    private protected UIThreadFixtureBase(UITestCase.SyncContextType synchronizationContextType)
+    {
+        this.SyncContextAdapter = UITestCase.GetAdapter(synchronizationContextType);
+        this.threadName = this.GetType().FullName ?? this.GetType().Name;
+    }
+
+    internal SyncContextAdapter SyncContextAdapter { get; }
+
+    internal ThreadRental ThreadRental => this.threadRental ?? throw new ObjectDisposedException(this.GetType().FullName);
+
+    /// <summary>
+    /// Gets the synchronization context for the shared UI thread.
+    /// </summary>
+    protected SynchronizationContext SynchronizationContext => this.ThreadRental.SynchronizationContext;
+
+    /// <inheritdoc/>
+    public async ValueTask InitializeAsync()
+    {
+        if (this.threadRental is not null)
+        {
+            throw new InvalidOperationException("The shared UI thread fixture has already been initialized.");
+        }
+
+        ThreadRental rental = await ThreadRental.CreateAsync(this.SyncContextAdapter, this.threadName);
+        if (Interlocked.CompareExchange(ref this.threadRental, rental, null) is not null)
+        {
+            rental.Dispose();
+            throw new InvalidOperationException("The shared UI thread fixture has already been initialized.");
+        }
+
+        try
+        {
+            await RunOnUIThreadAsync(rental, this.InitializeOnUIThreadAsync);
+        }
+        catch
+        {
+            this.threadRental = null;
+            rental.Dispose();
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        ThreadRental? rental = Interlocked.Exchange(ref this.threadRental, null);
+        if (rental is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await RunOnUIThreadAsync(rental, this.DisposeOnUIThreadAsync);
+        }
+        finally
+        {
+            rental.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Initializes the fixture on its shared UI thread.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="StaThreadFixture"/> does not install a synchronization context, so code after a yielding
+    /// <see langword="await"/> may resume on a thread-pool thread.
+    /// </remarks>
+    /// <returns>A task that completes when initialization has finished.</returns>
+    protected virtual ValueTask InitializeOnUIThreadAsync() => default;
+
+    /// <summary>
+    /// Disposes the fixture on its shared UI thread.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="StaThreadFixture"/> does not install a synchronization context, so code after a yielding
+    /// <see langword="await"/> may resume on a thread-pool thread.
+    /// </remarks>
+    /// <returns>A task that completes when disposal has finished.</returns>
+    protected virtual ValueTask DisposeOnUIThreadAsync() => default;
+
+    /// <summary>
+    /// Runs a callback on the shared UI thread.
+    /// </summary>
+    /// <param name="callback">The callback to run.</param>
+    /// <returns>A task that completes when the callback has finished.</returns>
+    protected ValueTask RunOnUIThreadAsync(Func<ValueTask> callback)
+    {
+        if (callback is null)
+        {
+            throw new ArgumentNullException(nameof(callback));
+        }
+
+        return RunOnUIThreadAsync(this.ThreadRental, callback);
+    }
+
+    private static async ValueTask RunOnUIThreadAsync(ThreadRental rental, Func<ValueTask> callback)
+    {
+        var completion = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        rental.SynchronizationContext.Post(
+            async _ =>
+            {
+                try
+                {
+                    await callback();
+                    completion.TrySetResult(null);
+                }
+                catch (Exception ex)
+                {
+                    completion.TrySetException(ex);
+                }
+            },
+            null);
+        await completion.Task.ConfigureAwait(false);
+    }
+}

--- a/src/Xunit.StaFact/UIThreadFixtureBase.cs
+++ b/src/Xunit.StaFact/UIThreadFixtureBase.cs
@@ -22,8 +22,14 @@ public abstract class UIThreadFixtureBase : IAsyncLifetime
         this.threadName = this.GetType().FullName ?? this.GetType().Name;
     }
 
+    /// <summary>
+    /// Gets the adapter that creates and pumps this fixture's synchronization context.
+    /// </summary>
     internal SyncContextAdapter SyncContextAdapter { get; }
 
+    /// <summary>
+    /// Gets the thread rental owned by this fixture.
+    /// </summary>
     internal ThreadRental ThreadRental => this.threadRental ?? throw new ObjectDisposedException(this.GetType().FullName);
 
     /// <summary>

--- a/src/Xunit.StaFact/WindowsDesktop/WinFormsThreadFixture.cs
+++ b/src/Xunit.StaFact/WindowsDesktop/WinFormsThreadFixture.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+using Xunit.Sdk;
+
+namespace Xunit;
+
+/// <summary>
+/// Provides a shared WinForms UI thread for <see cref="WinFormsFactAttribute"/> and <see cref="WinFormsTheoryAttribute"/> tests.
+/// </summary>
+public class WinFormsThreadFixture : UIThreadFixtureBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WinFormsThreadFixture"/> class.
+    /// </summary>
+    public WinFormsThreadFixture()
+        : base(UITestCase.SyncContextType.WinForms)
+    {
+    }
+}

--- a/src/Xunit.StaFact/WindowsDesktop/WpfThreadFixture.cs
+++ b/src/Xunit.StaFact/WindowsDesktop/WpfThreadFixture.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+using Xunit.Sdk;
+
+namespace Xunit;
+
+/// <summary>
+/// Provides a shared WPF UI thread for <see cref="WpfFactAttribute"/> and <see cref="WpfTheoryAttribute"/> tests.
+/// </summary>
+public class WpfThreadFixture : UIThreadFixtureBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WpfThreadFixture"/> class.
+    /// </summary>
+    public WpfThreadFixture()
+        : base(UITestCase.SyncContextType.WPF)
+    {
+    }
+}

--- a/test/Xunit.StaFact.Tests.Mac/SharedCocoaThreadFixtureTests.cs
+++ b/test/Xunit.StaFact.Tests.Mac/SharedCocoaThreadFixtureTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
 
+using Xunit;
+
 public class SharedCocoaThreadFixtureTests : IClassFixture<SharedCocoaThreadFixtureTests.TrackingCocoaThreadFixture>
 {
     private readonly TrackingCocoaThreadFixture fixture;

--- a/test/Xunit.StaFact.Tests.Mac/SharedCocoaThreadFixtureTests.cs
+++ b/test/Xunit.StaFact.Tests.Mac/SharedCocoaThreadFixtureTests.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+public class SharedCocoaThreadFixtureTests : IClassFixture<SharedCocoaThreadFixtureTests.TrackingCocoaThreadFixture>
+{
+    private readonly TrackingCocoaThreadFixture fixture;
+
+    public SharedCocoaThreadFixtureTests(TrackingCocoaThreadFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [CocoaFact]
+    public void FactUsesFixtureThread()
+    {
+        Assert.Equal(this.fixture.ThreadId, Environment.CurrentManagedThreadId);
+        Assert.NotNull(SynchronizationContext.Current);
+    }
+
+    public class TrackingCocoaThreadFixture : CocoaThreadFixture
+    {
+        public int ThreadId { get; private set; }
+
+        protected override ValueTask InitializeOnUIThreadAsync()
+        {
+            this.ThreadId = Environment.CurrentManagedThreadId;
+            Assert.NotNull(SynchronizationContext.Current);
+            return default;
+        }
+    }
+}

--- a/test/Xunit.StaFact.Tests/DirectUIThreadCollection.cs
+++ b/test/Xunit.StaFact.Tests/DirectUIThreadCollection.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+[CollectionDefinition(nameof(DirectUIThreadCollection))]
+public class DirectUIThreadCollection : ICollectionFixture<UIThreadFixture>
+{
+    private static int sharedThreadId;
+
+    public static void AssertSharedThread()
+    {
+        int threadId = Environment.CurrentManagedThreadId;
+        int previousThreadId = Interlocked.CompareExchange(ref sharedThreadId, threadId, 0);
+        Assert.True(previousThreadId is 0 || previousThreadId == threadId);
+    }
+}

--- a/test/Xunit.StaFact.Tests/DirectUIThreadCollectionTests1.cs
+++ b/test/Xunit.StaFact.Tests/DirectUIThreadCollectionTests1.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+[Collection(nameof(DirectUIThreadCollection))]
+public class DirectUIThreadCollectionTests1
+{
+    public DirectUIThreadCollectionTests1(UIThreadFixture fixture)
+    {
+    }
+
+    [UIFact]
+    public void UsesCollectionThread()
+    {
+        DirectUIThreadCollection.AssertSharedThread();
+    }
+}

--- a/test/Xunit.StaFact.Tests/DirectUIThreadCollectionTests2.cs
+++ b/test/Xunit.StaFact.Tests/DirectUIThreadCollectionTests2.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+[Collection(nameof(DirectUIThreadCollection))]
+public class DirectUIThreadCollectionTests2
+{
+    public DirectUIThreadCollectionTests2(UIThreadFixture fixture)
+    {
+    }
+
+    [UIFact]
+    public void UsesSameCollectionThread()
+    {
+        DirectUIThreadCollection.AssertSharedThread();
+    }
+}

--- a/test/Xunit.StaFact.Tests/DirectUIThreadFixtureTests.cs
+++ b/test/Xunit.StaFact.Tests/DirectUIThreadFixtureTests.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+public class DirectUIThreadFixtureTests : IClassFixture<UIThreadFixture>
+{
+    private static int sharedThreadId;
+
+    public DirectUIThreadFixtureTests(UIThreadFixture fixture)
+    {
+    }
+
+    [UIFact]
+    public void FactUsesSharedThread()
+    {
+        AssertSharedThread();
+    }
+
+    [UITheory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void TheoryUsesSharedThread(int value)
+    {
+        Assert.True(value > 0);
+        AssertSharedThread();
+    }
+
+    private static void AssertSharedThread()
+    {
+        int threadId = Environment.CurrentManagedThreadId;
+        int previousThreadId = Interlocked.CompareExchange(ref sharedThreadId, threadId, 0);
+        Assert.True(previousThreadId is 0 || previousThreadId == threadId);
+    }
+}

--- a/test/Xunit.StaFact.Tests/SharedUIThreadCollection.cs
+++ b/test/Xunit.StaFact.Tests/SharedUIThreadCollection.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+[CollectionDefinition(nameof(SharedUIThreadCollection))]
+public class SharedUIThreadCollection : ICollectionFixture<SharedUIThreadCollection.CollectionUIThreadFixture>
+{
+    public class CollectionUIThreadFixture : UIThreadFixture
+    {
+        public SynchronizationContext? Context { get; private set; }
+
+        public int ThreadId { get; private set; }
+
+        protected override ValueTask InitializeOnUIThreadAsync()
+        {
+            this.Context = SynchronizationContext.Current;
+            this.ThreadId = Environment.CurrentManagedThreadId;
+            return default;
+        }
+    }
+}

--- a/test/Xunit.StaFact.Tests/SharedUIThreadCollectionTests1.cs
+++ b/test/Xunit.StaFact.Tests/SharedUIThreadCollectionTests1.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+[Collection(nameof(SharedUIThreadCollection))]
+public class SharedUIThreadCollectionTests1
+{
+    private readonly SharedUIThreadCollection.CollectionUIThreadFixture fixture;
+
+    public SharedUIThreadCollectionTests1(SharedUIThreadCollection.CollectionUIThreadFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [UIFact]
+    public void UsesCollectionFixtureThread()
+    {
+        Assert.Equal(this.fixture.ThreadId, Environment.CurrentManagedThreadId);
+        Assert.Same(this.fixture.Context, SynchronizationContext.Current);
+    }
+}

--- a/test/Xunit.StaFact.Tests/SharedUIThreadCollectionTests2.cs
+++ b/test/Xunit.StaFact.Tests/SharedUIThreadCollectionTests2.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+[Collection(nameof(SharedUIThreadCollection))]
+public class SharedUIThreadCollectionTests2
+{
+    private readonly SharedUIThreadCollection.CollectionUIThreadFixture fixture;
+
+    public SharedUIThreadCollectionTests2(SharedUIThreadCollection.CollectionUIThreadFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [UIFact]
+    public void UsesSameCollectionFixtureThread()
+    {
+        Assert.Equal(this.fixture.ThreadId, Environment.CurrentManagedThreadId);
+        Assert.Same(this.fixture.Context, SynchronizationContext.Current);
+    }
+}

--- a/test/Xunit.StaFact.Tests/SharedUIThreadFixtureTests.cs
+++ b/test/Xunit.StaFact.Tests/SharedUIThreadFixtureTests.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+public class SharedUIThreadFixtureTests : IClassFixture<SharedUIThreadFixtureTests.TrackingUIThreadFixture>
+{
+    private readonly TrackingUIThreadFixture fixture;
+
+    public SharedUIThreadFixtureTests(TrackingUIThreadFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [UIFact]
+    public void FactUsesFixtureThread()
+    {
+        Assert.True(this.fixture.Initialized);
+        Assert.Equal(this.fixture.ThreadId, Environment.CurrentManagedThreadId);
+        Assert.Same(this.fixture.Context, SynchronizationContext.Current);
+    }
+
+    [UITheory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task TheoryUsesFixtureThread(int value)
+    {
+        Assert.True(value > 0);
+        Assert.Equal(this.fixture.ThreadId, Environment.CurrentManagedThreadId);
+        await Task.Yield();
+        Assert.Equal(this.fixture.ThreadId, Environment.CurrentManagedThreadId);
+    }
+
+    [Fact]
+    public async Task LifecycleHooksUseFixtureThread()
+    {
+        var fixture = new TrackingUIThreadFixture();
+        await fixture.InitializeAsync();
+
+        Assert.True(fixture.Initialized);
+        Assert.NotEqual(Environment.CurrentManagedThreadId, fixture.ThreadId);
+
+        await fixture.DisposeAsync();
+
+        Assert.True(fixture.Disposed);
+        Assert.Equal(fixture.ThreadId, fixture.DisposalThreadId);
+    }
+
+    [Fact]
+    public void IncompatibleFixtureIsRejected()
+    {
+        var uiFixture = new UIThreadFixture();
+        var staFixture = new StaThreadFixture();
+
+        InvalidOperationException exception = InvokeGetSharedThreadFixture([uiFixture], staFixture);
+
+        Assert.Contains("not compatible", exception.Message);
+    }
+
+    [Fact]
+    public void MultipleFixturesAreRejected()
+    {
+        var firstFixture = new UIThreadFixture();
+        var secondFixture = new UIThreadFixture();
+
+        InvalidOperationException exception = InvokeGetSharedThreadFixture([firstFixture, secondFixture], firstFixture);
+
+        Assert.Contains("only one", exception.Message);
+    }
+
+    private static InvalidOperationException InvokeGetSharedThreadFixture(object?[] constructorArguments, UIThreadFixtureBase adapterSource)
+    {
+        MethodInfo method = typeof(Xunit.Sdk.UITestCaseRunner).GetMethod("GetSharedThreadFixture", BindingFlags.NonPublic | BindingFlags.Static)!;
+        PropertyInfo adapterProperty = typeof(UIThreadFixtureBase).GetProperty("SyncContextAdapter", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        TargetInvocationException exception = Assert.Throws<TargetInvocationException>(
+            () => method.Invoke(null, [constructorArguments, adapterProperty.GetValue(adapterSource)]));
+        return Assert.IsType<InvalidOperationException>(exception.InnerException);
+    }
+
+    public class TrackingUIThreadFixture : UIThreadFixture
+    {
+        public SynchronizationContext? Context { get; private set; }
+
+        public int DisposalThreadId { get; private set; }
+
+        public bool Disposed { get; private set; }
+
+        public bool Initialized { get; private set; }
+
+        public int ThreadId { get; private set; }
+
+        protected override ValueTask InitializeOnUIThreadAsync()
+        {
+            this.Context = SynchronizationContext.Current;
+            this.ThreadId = Environment.CurrentManagedThreadId;
+            this.Initialized = true;
+            return default;
+        }
+
+        protected override ValueTask DisposeOnUIThreadAsync()
+        {
+            this.DisposalThreadId = Environment.CurrentManagedThreadId;
+            this.Disposed = true;
+            return default;
+        }
+    }
+}

--- a/test/Xunit.StaFact.Tests/WindowsDesktop/SharedStaThreadFixtureTests.cs
+++ b/test/Xunit.StaFact.Tests/WindowsDesktop/SharedStaThreadFixtureTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+public class SharedStaThreadFixtureTests : IClassFixture<SharedStaThreadFixtureTests.TrackingStaThreadFixture>
+{
+    private readonly TrackingStaThreadFixture fixture;
+
+    public SharedStaThreadFixtureTests(TrackingStaThreadFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [StaFact]
+    public void FactUsesFixtureThread()
+    {
+        Assert.Equal(this.fixture.ThreadId, Environment.CurrentManagedThreadId);
+        Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
+        Assert.Null(SynchronizationContext.Current);
+    }
+
+    [StaTheory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void TheoryUsesFixtureThread(int value)
+    {
+        Assert.True(value > 0);
+        Assert.Equal(this.fixture.ThreadId, Environment.CurrentManagedThreadId);
+        Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
+    }
+
+    public class TrackingStaThreadFixture : StaThreadFixture
+    {
+        public int ThreadId { get; private set; }
+
+        protected override ValueTask InitializeOnUIThreadAsync()
+        {
+            this.ThreadId = Environment.CurrentManagedThreadId;
+            Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
+            Assert.Null(SynchronizationContext.Current);
+            return default;
+        }
+    }
+}

--- a/test/Xunit.StaFact.Tests/WindowsDesktop/SharedWinFormsThreadFixtureTests.cs
+++ b/test/Xunit.StaFact.Tests/WindowsDesktop/SharedWinFormsThreadFixtureTests.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+using System.Windows.Forms;
+
+public class SharedWinFormsThreadFixtureTests : IClassFixture<SharedWinFormsThreadFixtureTests.TrackingWinFormsThreadFixture>
+{
+    private readonly TrackingWinFormsThreadFixture fixture;
+
+    public SharedWinFormsThreadFixtureTests(TrackingWinFormsThreadFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [WinFormsFact]
+    public void FactUsesFixtureThread()
+    {
+        Assert.Equal(this.fixture.ThreadId, Environment.CurrentManagedThreadId);
+        Assert.IsType<WindowsFormsSynchronizationContext>(SynchronizationContext.Current);
+    }
+
+    public class TrackingWinFormsThreadFixture : WinFormsThreadFixture
+    {
+        public int ThreadId { get; private set; }
+
+        protected override ValueTask InitializeOnUIThreadAsync()
+        {
+            this.ThreadId = Environment.CurrentManagedThreadId;
+            Assert.IsType<WindowsFormsSynchronizationContext>(SynchronizationContext.Current);
+            return default;
+        }
+    }
+}

--- a/test/Xunit.StaFact.Tests/WindowsDesktop/SharedWpfThreadFixtureTests.cs
+++ b/test/Xunit.StaFact.Tests/WindowsDesktop/SharedWpfThreadFixtureTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+using System.Windows.Threading;
+
+public class SharedWpfThreadFixtureTests : IClassFixture<SharedWpfThreadFixtureTests.TrackingWpfThreadFixture>
+{
+    private readonly TrackingWpfThreadFixture fixture;
+
+    public SharedWpfThreadFixtureTests(TrackingWpfThreadFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [WpfFact]
+    public async Task FactsUseFixtureDispatcher()
+    {
+        Assert.Equal(this.fixture.ThreadId, Environment.CurrentManagedThreadId);
+        Assert.IsType<DispatcherSynchronizationContext>(this.fixture.Context);
+        Assert.IsType<DispatcherSynchronizationContext>(SynchronizationContext.Current);
+
+        await Task.Yield();
+
+        Assert.Equal(this.fixture.ThreadId, Environment.CurrentManagedThreadId);
+    }
+
+    public class TrackingWpfThreadFixture : WpfThreadFixture
+    {
+        public SynchronizationContext? Context { get; private set; }
+
+        public int ThreadId { get; private set; }
+
+        protected override ValueTask InitializeOnUIThreadAsync()
+        {
+            this.Context = SynchronizationContext.Current;
+            this.ThreadId = Environment.CurrentManagedThreadId;
+            return default;
+        }
+    }
+}

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "4.0",
+  "version": "4.1-beta",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+\\.\\d+$"


### PR DESCRIPTION
UI tests currently receive a fresh STA/UI thread per test, which prevents thread-affine application state and fixture initialization from being shared safely across related tests.

This adds opt-in shared thread fixtures for portable UI, STA, WPF, WinForms, and Cocoa tests. Tests can inject the library-provided fixture directly at class or collection scope, or derive from it to run custom initialization and cleanup hooks on the owned UI thread. The existing per-test thread behavior remains the default.

The change also:
- validates fixture and test synchronization-context compatibility
- makes thread startup failures observable and cleanup execute on the owning thread
- covers direct and derived fixtures across class, collection, theory, and platform-specific scenarios
- adds compilable samples and detailed DocFX guidance linked to those samples

Fixture CLR constructors remain controlled by xUnit and are not moved onto the STA/UI thread; thread-affine setup belongs in the new lifecycle hooks.

Fixes #52
Fixes #54