### PR TITLE
Add WinUI fact and theory support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
     - name: 🔻 Download deployables artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: deployables-Windows # linux build omits the macOS APIs
+        name: deployables-Windows # linux build omits the macOS and Windows-specific APIs
         path: ${{ runner.temp }}/deployables
         run-id: ${{ steps.findrunid.outputs.runid }}
         github-token: ${{ github.token }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
-    <TargetingWindows Condition=" '$(TargetFramework)' == 'net472' or $(TargetFramework.EndsWith('-windows')) ">true</TargetingWindows>
+    <TargetingWindows Condition=" '$(TargetFramework)' == 'net472' or $(TargetFramework.Contains('-windows')) ">true</TargetingWindows>
     <TargetingMacos Condition="$(TargetFramework.Contains('macos'))">true</TargetingMacos>
     <RestoreEnablePackagePruning>true</RestoreEnablePackagePruning>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
 <XunitV3LibraryVersion>4.0.0</XunitV3LibraryVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.260804001" />
     <PackageVersion Include="xunit.analyzers" Version="2.0.0" />
     <PackageVersion Include="xunit.v3.assert" Version="$(XunitV3LibraryVersion)" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="$(XunitV3LibraryVersion)" />

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Build Status](https://dev.azure.com/andrewarnott/OSS/_apis/build/status/Xunit.StaFact)](https://dev.azure.com/andrewarnott/OSS/_build/latest?definitionId=22)
 [![NuGet package](https://img.shields.io/nuget/v/xunit.stafact.svg)][NuPkg]
 
-Run your xunit-based tests on an STA thread with the WPF Dispatcher, a WinForms SynchronizationContext, or even a cross-platform generic UI thread emulation with a SynchronizationContext that keeps code running on a "main thread" for that test.
+Run your xunit-based tests on an STA thread with the WPF Dispatcher, a WinForms or WinUI SynchronizationContext, or even a cross-platform generic UI thread emulation with a SynchronizationContext that keeps code running on a "main thread" for that test.
 
-Simply use `[WpfFact]`, `[WinFormsFact]`, `[StaFact]` or the cross-platform `[UIFact]` on your test method to run your test under conditions that most closely match the main thread in your application.
+Simply use `[WpfFact]`, `[WinFormsFact]`, `[WinUIFact]`, `[StaFact]` or the cross-platform `[UIFact]` on your test method to run your test under conditions that most closely match the main thread in your application.
 
 Theory variants of these attributes allow for parameterized testing. Check out the xunit.combinatorial nuget package for pairwise or combinatorial testing with theories.
 
@@ -30,6 +30,7 @@ Xunit test attributes            | Supported OS's   | SynchronizationContext    
 `[UIFact, UITheory]`             | All              | Yes<sup>1</sup>                                 | yes<sup>2</sup>            |
 `[WpfFact, WpfTheory]`           | Windows only<sup>3</sup>    | `DispatcherSynchronizationContext`   | yes             |
 `[WinFormsFact, WinFormsTheory]` | Windows only<sup>3</sup>    | `WindowsFormsSynchronizationContext` | yes             |
+`[WinUIFact, WinUITheory]`       | Windows 10 1809+<sup>4</sup> | `DispatcherQueueSynchronizationContext` | yes          |
 `[StaFact, StaTheory]`           | Windows only<sup>3</sup>    | No                                   | yes             |
 `[CocoaFact, CocoaTheory]`       | Mac OSX only<sup>3</sup>    | Yes<sup>1</sup>                                 | no              |
 
@@ -39,13 +40,15 @@ Xunit test attributes            | Supported OS's   | SynchronizationContext    
 
 <sup>3</sup> Windows-only attributes result in the test to result in "Skipped" on other operating systems.
 
+<sup>4</sup> WinUI attributes require a Windows-versioned target framework such as `net8.0-windows10.0.17763.0`.
+
 We also offer a `[UISettingsAttribute]` that can be applied to individual test methods or test classes to control the behavior of the various UI test attributes.
 This attribute offers a means to add automated retries to a test's execution for unstable tests.
 
 ## Samples
 
 ```csharp
-[UIFact] // or [WinFormsFact] or [WpfFact]
+[UIFact] // or [WinFormsFact], [WpfFact], or [WinUIFact]
 public async Task WpfFact_OnSTAThread()
 {
     Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());

--- a/docfx/docs/features.md
+++ b/docfx/docs/features.md
@@ -7,6 +7,7 @@ Xunit test attributes            | Supported OS's   | SynchronizationContext    
 @Xunit.UIFactAttribute, @Xunit.UITheoryAttribute | All              | Yes[^1]                              | yes[^2]         |
 @Xunit.WpfFactAttribute, @Xunit.WpfTheoryAttribute           | Windows only[^3] | @System.Windows.Threading.DispatcherSynchronizationContext   | yes             |
 @Xunit.WinFormsFactAttribute, @Xunit.WinFormsTheoryAttribute | Windows only[^3] | @System.Windows.Forms.WindowsFormsSynchronizationContext | yes             |
+@Xunit.WinUIFactAttribute, @Xunit.WinUITheoryAttribute       | Windows 10 1809+[^4] | @Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext | yes       |
 @Xunit.StaFactAttribute, @Xunit.StaTheoryAttribute           | Windows only[^3] | No                                   | yes             |
 @Xunit.CocoaFactAttribute, @Xunit.CocoaTheoryAttribute       | Mac OSX only[^3] | Yes[^1]                              | no              |
 
@@ -28,6 +29,7 @@ Test attribute | Compatible fixture
 @Xunit.StaFactAttribute, @Xunit.StaTheoryAttribute | @Xunit.StaThreadFixture
 @Xunit.WpfFactAttribute, @Xunit.WpfTheoryAttribute | @Xunit.WpfThreadFixture
 @Xunit.WinFormsFactAttribute, @Xunit.WinFormsTheoryAttribute | @Xunit.WinFormsThreadFixture
+@Xunit.WinUIFactAttribute, @Xunit.WinUITheoryAttribute | @Xunit.WinUIThreadFixture
 @Xunit.CocoaFactAttribute, @Xunit.CocoaTheoryAttribute | @Xunit.CocoaThreadFixture
 
 ### Class scope
@@ -65,7 +67,7 @@ and cleanup runs before that thread is shut down.
 
 [!code-csharp[](../../samples/SharedThreadSamples.cs#SharedThreadFixture)]
 
-The portable UI, WPF, WinForms, and Cocoa fixtures install their corresponding synchronization context.
+The portable UI, WPF, WinForms, WinUI, and Cocoa fixtures install their corresponding synchronization context.
 The STA fixture intentionally does not install one, matching @Xunit.StaFactAttribute behavior; after a yielding
 `await`, code may resume on a thread-pool thread.
 
@@ -84,3 +86,5 @@ The STA fixture intentionally does not install one, matching @Xunit.StaFactAttri
 [^2]: STA thread only applies on Windows. On other operating systems, an MTA thread is used.
 
 [^3]: Windows-only attributes result in the test to result in "Skipped" on other operating systems.
+
+[^4]: WinUI attributes require a Windows-versioned target framework such as `net8.0-windows10.0.17763.0`.

--- a/docfx/docs/features.md
+++ b/docfx/docs/features.md
@@ -17,7 +17,9 @@ This attribute offers a means to add automated retries to a test's execution for
 ## Shared UI thread fixtures
 
 By default, every fact or theory in this package runs on a newly created thread that is disposed when that test finishes.
-This avoids sharing thread-affine state and allows unrelated tests to run concurrently.
+This avoids sharing thread-affine state and allows unrelated tests to run concurrently. WinUI tests still get a fresh
+thread, but their XAML lifetimes are serialized within the process because overlapping WinUI XAML managers can terminate
+the test process.
 
 Some UI frameworks retain thread-affine objects in static caches, or a suite may intentionally host an application-level
 object for several tests. In those cases, opt in to a shared thread with an xUnit class or collection fixture.

--- a/docfx/docs/getting-started.md
+++ b/docfx/docs/getting-started.md
@@ -32,6 +32,25 @@ More closely resembles WinForms-specific semantics including a WinForms-specific
 
 [!code-csharp[](../../samples/SampleTests.cs#WinFormsFact)]
 
+### WinUI
+
+Use @Xunit.WinUIFactAttribute or @Xunit.WinUITheoryAttribute to initialize WinUI XAML and run a test with a
+@Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext. The test project must use a Windows-versioned
+target framework such as `net8.0-windows10.0.17763.0`.
+
+```csharp
+[WinUIFact]
+public async Task ControlStaysOnDispatcherQueue()
+{
+    var button = new Microsoft.UI.Xaml.Controls.Button();
+    Assert.True(button.DispatcherQueue.HasThreadAccess);
+
+    await Task.Yield();
+
+    Assert.True(button.DispatcherQueue.HasThreadAccess);
+}
+```
+
 ### STA thread
 
 Guarantees the test to run on an STA thread.

--- a/docfx/docs/getting-started.md
+++ b/docfx/docs/getting-started.md
@@ -38,6 +38,18 @@ Use @Xunit.WinUIFactAttribute or @Xunit.WinUITheoryAttribute to initialize WinUI
 @Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext. The test project must use a Windows-versioned
 target framework such as `net8.0-windows10.0.17763.0`.
 
+An unpackaged test executable that uses these attributes must also enable Windows App SDK bootstrap initialization:
+
+```xml
+<PropertyGroup>
+  <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+  <WindowsPackageType>None</WindowsPackageType>
+  <WindowsAppSdkBootstrapInitialize>true</WindowsAppSdkBootstrapInitialize>
+</PropertyGroup>
+```
+
+These properties are not required for projects that use only the portable UI, STA, WPF, or WinForms attributes.
+
 ```csharp
 [WinUIFact]
 public async Task ControlStaysOnDispatcherQueue()

--- a/docfx/docs/getting-started.md
+++ b/docfx/docs/getting-started.md
@@ -44,10 +44,15 @@ An unpackaged test executable that uses these attributes must also enable Window
 <PropertyGroup>
   <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
   <WindowsPackageType>None</WindowsPackageType>
-  <WindowsAppSdkBootstrapInitialize>true</WindowsAppSdkBootstrapInitialize>
+  <WindowsAppSdkBootstrapInitialize>false</WindowsAppSdkBootstrapInitialize>
+  <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+  <RuntimeIdentifier>win-x64</RuntimeIdentifier>
 </PropertyGroup>
 ```
 
+`WindowsAppSDKSelfContained` allows tests to run on machines that do not have the Windows App SDK runtime installed.
+Choose a runtime identifier that matches the test process architecture. For a framework-dependent test host instead,
+omit `WindowsAppSDKSelfContained` and `RuntimeIdentifier`, and set `WindowsAppSdkBootstrapInitialize` to `true`.
 These properties are not required for projects that use only the portable UI, STA, WPF, or WinForms attributes.
 
 ```csharp

--- a/src/Xunit.StaFact/README.md
+++ b/src/Xunit.StaFact/README.md
@@ -1,6 +1,8 @@
-Run your xunit-based tests on an STA thread with the WPF Dispatcher, a WinForms SynchronizationContext, or even a cross-platform generic UI thread emulation with a SynchronizationContext that keeps code running on a "main thread" for that test.
+Run your xunit-based tests on an STA thread with the WPF Dispatcher, a WinForms or WinUI SynchronizationContext, or even a cross-platform generic UI thread emulation with a SynchronizationContext that keeps code running on a "main thread" for that test.
 
-Simply use `[WpfFact]`, `[WinFormsFact]`, `[StaFact]` or the cross-platform `[UIFact]` on your test method to run your test under conditions that most closely match the main thread in your application.
+Simply use `[WpfFact]`, `[WinFormsFact]`, `[WinUIFact]`, `[StaFact]` or the cross-platform `[UIFact]` on your test method to run your test under conditions that most closely match the main thread in your application.
+
+WinUI attributes require a Windows-versioned target framework such as `net8.0-windows10.0.17763.0`.
 
 Theory variants of these attributes allow for parameterized testing. Check out the xunit.combinatorial NuGet package for pairwise or combinatorial testing with theories.
 

--- a/src/Xunit.StaFact/Sdk.WindowsDesktop/WinUIFactDiscoverer.cs
+++ b/src/Xunit.StaFact/Sdk.WindowsDesktop/WinUIFactDiscoverer.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+#if WINDOWS10_0_17763_0_OR_GREATER
+
+namespace Xunit.Sdk;
+
+/// <summary>
+/// The discovery class for <see cref="WinUIFactAttribute"/>.
+/// </summary>
+public class WinUIFactDiscoverer : FactDiscoverer
+{
+    /// <inheritdoc/>
+    protected override IXunitTestCase CreateTestCase(ITestFrameworkDiscoveryOptions discoveryOptions, IXunitTestMethod testMethod, IFactAttribute factAttribute)
+    {
+        return WinUIUtilities.CreateTestCaseForFact(
+            discoveryOptions,
+            testMethod,
+            factAttribute);
+    }
+}
+
+#endif

--- a/src/Xunit.StaFact/Sdk.WindowsDesktop/WinUISynchronizationContextAdapter.cs
+++ b/src/Xunit.StaFact/Sdk.WindowsDesktop/WinUISynchronizationContextAdapter.cs
@@ -12,8 +12,13 @@ internal class WinUISynchronizationContextAdapter : SyncContextAdapter
 {
     internal static readonly SyncContextAdapter Default = new WinUISynchronizationContextAdapter();
 
+    private static readonly SemaphoreSlim XamlManagerGate = new(1, 1);
+
     [ThreadStatic]
     private static DispatcherQueueController? dispatcherQueueController;
+
+    [ThreadStatic]
+    private static bool ownsXamlManagerGate;
 
     [ThreadStatic]
     private static WindowsXamlManager? windowsXamlManager;
@@ -24,16 +29,22 @@ internal class WinUISynchronizationContextAdapter : SyncContextAdapter
 
     internal override SynchronizationContext Create(string name)
     {
-        dispatcherQueueController = DispatcherQueueController.CreateOnCurrentThread();
+        XamlManagerGate.Wait();
+        ownsXamlManagerGate = true;
         try
         {
+            dispatcherQueueController = DispatcherQueueController.CreateOnCurrentThread();
             windowsXamlManager = WindowsXamlManager.InitializeForCurrentThread();
             return new DispatcherQueueSynchronizationContext(dispatcherQueueController.DispatcherQueue);
         }
         catch
         {
-            dispatcherQueueController.ShutdownQueue();
+            windowsXamlManager?.Dispose();
+            windowsXamlManager = null;
+            dispatcherQueueController?.ShutdownQueue();
             dispatcherQueueController = null;
+            ownsXamlManagerGate = false;
+            XamlManagerGate.Release();
             throw;
         }
     }
@@ -48,9 +59,20 @@ internal class WinUISynchronizationContextAdapter : SyncContextAdapter
             CancellationToken.None,
             TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default);
-        controller.DispatcherQueue.RunEventLoop();
-        controller.ShutdownQueue();
-        dispatcherQueueController = null;
+        try
+        {
+            controller.DispatcherQueue.RunEventLoop();
+        }
+        finally
+        {
+            controller.ShutdownQueue();
+            dispatcherQueueController = null;
+            if (ownsXamlManagerGate)
+            {
+                ownsXamlManagerGate = false;
+                XamlManagerGate.Release();
+            }
+        }
     }
 
     internal override void Cleanup(SynchronizationContext synchronizationContext)

--- a/src/Xunit.StaFact/Sdk.WindowsDesktop/WinUISynchronizationContextAdapter.cs
+++ b/src/Xunit.StaFact/Sdk.WindowsDesktop/WinUISynchronizationContextAdapter.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+#if WINDOWS10_0_17763_0_OR_GREATER
+
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml.Hosting;
+
+namespace Xunit.Sdk;
+
+internal class WinUISynchronizationContextAdapter : SyncContextAdapter
+{
+    internal static readonly SyncContextAdapter Default = new WinUISynchronizationContextAdapter();
+
+    [ThreadStatic]
+    private static DispatcherQueueController? dispatcherQueueController;
+
+    [ThreadStatic]
+    private static WindowsXamlManager? windowsXamlManager;
+
+    private WinUISynchronizationContextAdapter()
+    {
+    }
+
+    internal override SynchronizationContext Create(string name)
+    {
+        dispatcherQueueController = DispatcherQueueController.CreateOnCurrentThread();
+        try
+        {
+            windowsXamlManager = WindowsXamlManager.InitializeForCurrentThread();
+            return new DispatcherQueueSynchronizationContext(dispatcherQueueController.DispatcherQueue);
+        }
+        catch
+        {
+            dispatcherQueueController.ShutdownQueue();
+            dispatcherQueueController = null;
+            throw;
+        }
+    }
+
+    internal override void PumpTill(SynchronizationContext synchronizationContext, Task task)
+    {
+        DispatcherQueueController controller = dispatcherQueueController
+            ?? throw new InvalidOperationException("The WinUI dispatcher queue has not been initialized.");
+
+        _ = task.ContinueWith(
+            _ => controller.DispatcherQueue.EnqueueEventLoopExit(),
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+        controller.DispatcherQueue.RunEventLoop();
+        controller.ShutdownQueue();
+        dispatcherQueueController = null;
+    }
+
+    internal override void Cleanup(SynchronizationContext synchronizationContext)
+    {
+        if (SynchronizationContext.Current == synchronizationContext)
+        {
+            this.Cleanup();
+            return;
+        }
+
+        var completion = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        synchronizationContext.Post(
+            _ =>
+            {
+                try
+                {
+                    this.Cleanup();
+                    completion.TrySetResult(null);
+                }
+                catch (Exception ex)
+                {
+                    completion.TrySetException(ex);
+                }
+            },
+            null);
+        completion.Task.GetAwaiter().GetResult();
+    }
+
+    internal override void Cleanup()
+    {
+        windowsXamlManager?.Dispose();
+        windowsXamlManager = null;
+    }
+}
+
+#endif

--- a/src/Xunit.StaFact/Sdk.WindowsDesktop/WinUITheoryDiscoverer.cs
+++ b/src/Xunit.StaFact/Sdk.WindowsDesktop/WinUITheoryDiscoverer.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+#if WINDOWS10_0_17763_0_OR_GREATER
+
+namespace Xunit.Sdk;
+
+/// <summary>
+/// The discovery class for <see cref="WinUITheoryAttribute"/>.
+/// </summary>
+public class WinUITheoryDiscoverer : TheoryDiscoverer
+{
+    /// <inheritdoc/>
+    protected override ValueTask<IReadOnlyCollection<IXunitTestCase>> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, IXunitTestMethod testMethod, ITheoryAttribute theoryAttribute, ITheoryDataRow dataRow, object?[] testMethodArguments, string? index)
+    {
+        IXunitTestCase testCase = WinUIUtilities.CreateTestCaseForDataRow(
+            discoveryOptions,
+            testMethod,
+            theoryAttribute,
+            dataRow,
+            testMethodArguments);
+        return new([testCase]);
+    }
+
+    /// <inheritdoc/>
+    protected override ValueTask<IReadOnlyCollection<IXunitTestCase>> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, IXunitTestMethod testMethod, ITheoryAttribute theoryAttribute)
+    {
+        IXunitTestCase testCase = WinUIUtilities.CreateTestCaseForTheory(
+            discoveryOptions,
+            testMethod,
+            theoryAttribute);
+        return new([testCase]);
+    }
+}
+
+#endif

--- a/src/Xunit.StaFact/Sdk.WindowsDesktop/WinUIUtilities.cs
+++ b/src/Xunit.StaFact/Sdk.WindowsDesktop/WinUIUtilities.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+#if WINDOWS10_0_17763_0_OR_GREATER
+
+using System.Runtime.InteropServices;
+
+namespace Xunit.Sdk;
+
+internal static class WinUIUtilities
+{
+    private const UITestCase.SyncContextType ContextType = UITestCase.SyncContextType.WinUI;
+    private static readonly string? SkipReason = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? null : "WinUI only exists on Windows.";
+
+    internal static IXunitTestCase CreateTestCaseForFact(
+        ITestFrameworkDiscoveryOptions discoveryOptions,
+        IXunitTestMethod testMethod,
+        IFactAttribute factAttribute)
+    {
+        return Utilities.CreateTestCaseForFact(
+            ContextType,
+            SkipReason,
+            discoveryOptions,
+            testMethod,
+            factAttribute);
+    }
+
+    internal static IXunitTestCase CreateTestCaseForDataRow(
+        ITestFrameworkDiscoveryOptions discoveryOptions,
+        IXunitTestMethod testMethod,
+        ITheoryAttribute theoryAttribute,
+        ITheoryDataRow dataRow,
+        object?[] testMethodArguments)
+    {
+        return Utilities.CreateTestCaseForDataRow(
+            ContextType,
+            SkipReason,
+            discoveryOptions,
+            testMethod,
+            theoryAttribute,
+            dataRow,
+            testMethodArguments);
+    }
+
+    internal static IXunitTestCase CreateTestCaseForTheory(
+        ITestFrameworkDiscoveryOptions discoveryOptions,
+        IXunitTestMethod testMethod,
+        ITheoryAttribute theoryAttribute)
+    {
+        return Utilities.CreateTestCaseForTheory(
+            ContextType,
+            SkipReason,
+            discoveryOptions,
+            testMethod,
+            theoryAttribute);
+    }
+}
+
+#endif

--- a/src/Xunit.StaFact/Sdk/SyncContextAdapter.cs
+++ b/src/Xunit.StaFact/Sdk/SyncContextAdapter.cs
@@ -33,6 +33,13 @@ internal abstract class SyncContextAdapter
     internal abstract void PumpTill(SynchronizationContext syncContext, Task task);
 
     /// <summary>
+    /// Runs cleanup on the synchronization context thread.
+    /// </summary>
+    /// <param name="syncContext">The synchronization context to clean up.</param>
+    internal virtual void Cleanup(SynchronizationContext syncContext)
+        => syncContext.Send(_ => this.Cleanup(), null);
+
+    /// <summary>
     /// Clean up this instance.
     /// </summary>
     internal virtual void Cleanup()

--- a/src/Xunit.StaFact/Sdk/ThreadRental.cs
+++ b/src/Xunit.StaFact/Sdk/ThreadRental.cs
@@ -44,7 +44,7 @@ internal class ThreadRental : IDisposable
 
         try
         {
-            this.syncContext.Send(_ => this.SyncContextAdapter.Cleanup(), null);
+            this.SyncContextAdapter.Cleanup(this.syncContext);
         }
         finally
         {

--- a/src/Xunit.StaFact/Sdk/UITestCase.cs
+++ b/src/Xunit.StaFact/Sdk/UITestCase.cs
@@ -97,6 +97,13 @@ public class UITestCase : XunitTestCase, ISelfExecutingXunitTestCase
         /// Use the <see cref="System.Windows.Forms.WindowsFormsSynchronizationContext"/>, which is only available on Desktop.
         /// </summary>
         WinForms,
+
+#if WINDOWS10_0_17763_0_OR_GREATER
+        /// <summary>
+        /// Use the <see cref="Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext"/>, which is available with WinUI.
+        /// </summary>
+        WinUI,
+#endif
 #endif
     }
 
@@ -149,6 +156,11 @@ public class UITestCase : XunitTestCase, ISelfExecutingXunitTestCase
 
             case SyncContextType.WinForms:
                 return WinFormsSynchronizationContextAdapter.Default;
+
+#if WINDOWS10_0_17763_0_OR_GREATER
+            case SyncContextType.WinUI:
+                return WinUISynchronizationContextAdapter.Default;
+#endif
 #endif
             default:
                 throw new NotSupportedException("Unsupported type of SynchronizationContext.");

--- a/src/Xunit.StaFact/WindowsDesktop/WinUIFactAttribute.cs
+++ b/src/Xunit.StaFact/WindowsDesktop/WinUIFactAttribute.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+#if WINDOWS10_0_17763_0_OR_GREATER
+
+using System.Runtime.CompilerServices;
+using Microsoft.UI.Dispatching;
+using Xunit.Sdk;
+
+namespace Xunit;
+
+/// <summary>
+/// Identifies an xunit test that starts on an STA thread
+/// with a WinUI <see cref="DispatcherQueueSynchronizationContext"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+[XunitTestCaseDiscoverer(typeof(WinUIFactDiscoverer))]
+public class WinUIFactAttribute : FactAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WinUIFactAttribute"/> class.
+    /// </summary>
+    public WinUIFactAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
+    {
+    }
+}
+
+#endif

--- a/src/Xunit.StaFact/WindowsDesktop/WinUITheoryAttribute.cs
+++ b/src/Xunit.StaFact/WindowsDesktop/WinUITheoryAttribute.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+#if WINDOWS10_0_17763_0_OR_GREATER
+
+using System.Runtime.CompilerServices;
+using Microsoft.UI.Dispatching;
+using Xunit.Sdk;
+
+namespace Xunit;
+
+/// <summary>
+/// Identifies an xunit theory that starts on an STA thread
+/// with a WinUI <see cref="DispatcherQueueSynchronizationContext"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+[XunitTestCaseDiscoverer(typeof(WinUITheoryDiscoverer))]
+public class WinUITheoryAttribute : TheoryAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WinUITheoryAttribute"/> class.
+    /// </summary>
+    public WinUITheoryAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
+    {
+    }
+}
+
+#endif

--- a/src/Xunit.StaFact/WindowsDesktop/WinUIThreadFixture.cs
+++ b/src/Xunit.StaFact/WindowsDesktop/WinUIThreadFixture.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+#if WINDOWS10_0_17763_0_OR_GREATER
+
+using Xunit.Sdk;
+
+namespace Xunit;
+
+/// <summary>
+/// Provides a shared WinUI thread for <see cref="WinUIFactAttribute"/> and <see cref="WinUITheoryAttribute"/> tests.
+/// </summary>
+public class WinUIThreadFixture : UIThreadFixtureBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WinUIThreadFixture"/> class.
+    /// </summary>
+    public WinUIThreadFixture()
+        : base(UITestCase.SyncContextType.WinUI)
+    {
+    }
+}
+
+#endif

--- a/src/Xunit.StaFact/Xunit.StaFact.csproj
+++ b/src/Xunit.StaFact/Xunit.StaFact.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- The first TFM to be listed is the lucky one that determines which files show up in Solution Explorer. -->
-    <TargetFrameworks>net472;netstandard2.0;net8.0;net8.0-windows;net8.0-windows10.0.17763.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;net8.0;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net8.0-windows10.0.17763.0</TargetFrameworks>
     <!-- Exclude for Linux and Windows, which do not support building macOS projects
          (see https://github.com/xamarin/xamarin-macios/issues/17287). -->
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('OSX'))">$(TargetFrameworks);net9.0-macos15.0</TargetFrameworks>

--- a/src/Xunit.StaFact/Xunit.StaFact.csproj
+++ b/src/Xunit.StaFact/Xunit.StaFact.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- The first TFM to be listed is the lucky one that determines which files show up in Solution Explorer. -->
-    <TargetFrameworks>net472;netstandard2.0;net8.0;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;net8.0;net8.0-windows;net8.0-windows10.0.17763.0</TargetFrameworks>
     <!-- Exclude for Linux and Windows, which do not support building macOS projects
          (see https://github.com/xamarin/xamarin-macios/issues/17287). -->
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('OSX'))">$(TargetFrameworks);net9.0-macos15.0</TargetFrameworks>
     <RootNamespace>Xunit</RootNamespace>
 
-    <Description>Run your xunit-based tests on an STA thread with the WPF Dispatcher, a WinForms SynchronizationContext, or even a cross-platform generic UI thread emulation with a SynchronizationContext that keeps code running on a "main thread" for that test.
+    <Description>Run your xunit-based tests on an STA thread with the WPF Dispatcher, a WinForms or WinUI SynchronizationContext, or even a cross-platform generic UI thread emulation with a SynchronizationContext that keeps code running on a "main thread" for that test.
 
-Simply use [WpfFact], [WinFormsFact], [StaFact] or the cross-platform [UIFact] on your test method to run your test under conditions that most closely match the main thread in your application.
+Simply use [WpfFact], [WinFormsFact], [WinUIFact], [StaFact] or the cross-platform [UIFact] on your test method to run your test under conditions that most closely match the main thread in your application.
 
 Theory variants of these attributes allow for parameterized testing. Check out the xunit.combinatorial nuget package for pairwise or combinatorial testing with theories.</Description>
-    <PackageTags>STA xunit testing unit WPF WinForms testing</PackageTags>
+    <PackageTags>STA xunit testing unit WPF WinForms WinUI testing</PackageTags>
     <PackageValidationBaselineVersion>3.0.13</PackageValidationBaselineVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -33,6 +33,7 @@ Theory variants of these attributes allow for parameterized testing. Check out t
     <None Include="@(ExcludedCompileItems)" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Condition="'$(TargetFramework)'=='net8.0-windows10.0.17763.0'" />
     <PackageReference Include="xunit.v3.extensibility.core" />
   </ItemGroup>
 </Project>

--- a/test/Xunit.StaFact.Tests/WindowsDesktop/SharedWinUIThreadFixtureTests.cs
+++ b/test/Xunit.StaFact.Tests/WindowsDesktop/SharedWinUIThreadFixtureTests.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+#if WINDOWS10_0_17763_0_OR_GREATER
+
+using Microsoft.UI.Dispatching;
+
+public class SharedWinUIThreadFixtureTests : IClassFixture<SharedWinUIThreadFixtureTests.TrackingWinUIThreadFixture>
+{
+    private readonly TrackingWinUIThreadFixture fixture;
+
+    public SharedWinUIThreadFixtureTests(TrackingWinUIThreadFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [WinUIFact]
+    public async Task FactsUseFixtureDispatcher()
+    {
+        Assert.Equal(this.fixture.ThreadId, Environment.CurrentManagedThreadId);
+        Assert.IsType<DispatcherQueueSynchronizationContext>(this.fixture.Context);
+        Assert.IsType<DispatcherQueueSynchronizationContext>(SynchronizationContext.Current);
+
+        await Task.Yield();
+
+        Assert.Equal(this.fixture.ThreadId, Environment.CurrentManagedThreadId);
+    }
+
+    public class TrackingWinUIThreadFixture : WinUIThreadFixture
+    {
+        public SynchronizationContext? Context { get; private set; }
+
+        public int ThreadId { get; private set; }
+
+        protected override ValueTask InitializeOnUIThreadAsync()
+        {
+            this.Context = SynchronizationContext.Current;
+            this.ThreadId = Environment.CurrentManagedThreadId;
+            return default;
+        }
+    }
+}
+
+#endif

--- a/test/Xunit.StaFact.Tests/WindowsDesktop/WinUIFactTests.cs
+++ b/test/Xunit.StaFact.Tests/WindowsDesktop/WinUIFactTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+#if WINDOWS10_0_17763_0_OR_GREATER
+
+using System.Reflection;
+using Microsoft.UI.Dispatching;
+using WinUIButton = Microsoft.UI.Xaml.Controls.Button;
+using WinUIWindow = Microsoft.UI.Xaml.Window;
+
+public class WinUIFactTests
+{
+    private readonly Thread ctorThread;
+    private readonly SynchronizationContext? ctorSyncContext;
+
+    public WinUIFactTests()
+    {
+        this.ctorThread = Thread.CurrentThread;
+        this.ctorSyncContext = SynchronizationContext.Current;
+    }
+
+    [WinUIFact]
+    public void Void()
+    {
+        this.AssertThreadCharacteristics();
+    }
+
+    [WinUIFact]
+    public async Task AsyncTask()
+    {
+        this.AssertThreadCharacteristics();
+        await Task.Yield();
+        this.AssertThreadCharacteristics();
+    }
+
+    [WinUIFact]
+    public void CanCreateControlsAndWindows()
+    {
+        var button = new WinUIButton();
+        var window = new WinUIWindow();
+
+        Assert.True(button.DispatcherQueue.HasThreadAccess);
+        Assert.True(window.DispatcherQueue.HasThreadAccess);
+    }
+
+    [WinUIFact, Trait("TestCategory", "FailureExpected")]
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+    public async void AsyncVoid_IsNotSupported()
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+    {
+    }
+
+    [WinUIFact, Trait("TestCategory", "FailureExpected")]
+    public async Task FailAfterYield_Task()
+    {
+        await Task.Yield();
+        Assert.False(true);
+    }
+
+    [WinUIFact, Trait("TestCategory", "FailureExpected")]
+    public async Task FailAfterDelay_Task()
+    {
+        await Task.Delay(10);
+        Assert.False(true);
+    }
+
+    [WinUIFact, Trait("TestCategory", "FailureExpected")]
+    public async Task OperationCanceledException_Thrown()
+    {
+        await Task.Yield();
+        throw new OperationCanceledException();
+    }
+
+    [WinUIFact, Trait("TestCategory", "FailureExpected")]
+    public void JustFailVoid() => throw new InvalidOperationException("Expected failure.");
+
+    [WinUIFact]
+    [UISettings(MaxAttempts = 2)]
+    public void AutomaticRetryNeeded() => MaxAttemptsHelper.ThrowUnlessAttemptNumber(this.GetType(), MethodBase.GetCurrentMethod()!.Name, 2);
+
+    [WinUIFact]
+    [UISettings(MaxAttempts = 2)]
+    public void AutomaticRetryNotNeeded() => MaxAttemptsHelper.ThrowUnlessAttemptNumber(this.GetType(), MethodBase.GetCurrentMethod()!.Name, 1);
+
+    [WinUIFact, Trait("TestCategory", "FailureExpected")]
+    [UISettings(MaxAttempts = 2)]
+    public void FailsAllRetries()
+    {
+        Assert.Fail("Failure expected.");
+    }
+
+    [WinUIFact(SkipExceptions = [typeof(SkipOnThisException)])]
+    public void CanSkipOnSpecificExceptions()
+    {
+        throw new SkipOnThisException();
+    }
+
+    private void AssertThreadCharacteristics()
+    {
+        Assert.Same(this.ctorSyncContext, SynchronizationContext.Current);
+        Assert.IsType<DispatcherQueueSynchronizationContext>(SynchronizationContext.Current);
+        Assert.Same(this.ctorThread, Thread.CurrentThread);
+        Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
+        Assert.True(DispatcherQueue.GetForCurrentThread().HasThreadAccess);
+    }
+}
+
+#endif

--- a/test/Xunit.StaFact.Tests/WindowsDesktop/WinUITheoryTests.cs
+++ b/test/Xunit.StaFact.Tests/WindowsDesktop/WinUITheoryTests.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+#if WINDOWS10_0_17763_0_OR_GREATER
+
+using Microsoft.UI.Dispatching;
+
+public class WinUITheoryTests
+{
+    [WinUITheory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public async Task WinUITheory_OnSTAThread(int arg)
+    {
+        Assert.IsType<DispatcherQueueSynchronizationContext>(SynchronizationContext.Current);
+        Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
+        await Task.Yield();
+        Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
+        Assert.IsType<DispatcherQueueSynchronizationContext>(SynchronizationContext.Current);
+        Assert.True(arg == 0 || arg == 1);
+    }
+}
+
+#endif

--- a/test/Xunit.StaFact.Tests/Xunit.StaFact.Tests.csproj
+++ b/test/Xunit.StaFact.Tests/Xunit.StaFact.Tests.csproj
@@ -1,8 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-windows;net8.0-windows10.0.17763.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-windows10.0.17763.0'">
+    <UseWinUI>true</UseWinUI>
+    <WindowsPackageType>None</WindowsPackageType>
   </PropertyGroup>
   <ItemGroup>
     <ExcludedCompileItems Include="@(Compile)" />

--- a/test/Xunit.StaFact.Tests/Xunit.StaFact.Tests.csproj
+++ b/test/Xunit.StaFact.Tests/Xunit.StaFact.Tests.csproj
@@ -6,7 +6,9 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-windows10.0.17763.0'">
     <WindowsPackageType>None</WindowsPackageType>
-    <WindowsAppSdkBootstrapInitialize>true</WindowsAppSdkBootstrapInitialize>
+    <WindowsAppSdkBootstrapInitialize>false</WindowsAppSdkBootstrapInitialize>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <ExcludedCompileItems Include="@(Compile)" />

--- a/test/Xunit.StaFact.Tests/Xunit.StaFact.Tests.csproj
+++ b/test/Xunit.StaFact.Tests/Xunit.StaFact.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-windows;net8.0-windows10.0.17763.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net8.0-windows10.0.17763.0;net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-windows10.0.17763.0'">

--- a/test/Xunit.StaFact.Tests/Xunit.StaFact.Tests.csproj
+++ b/test/Xunit.StaFact.Tests/Xunit.StaFact.Tests.csproj
@@ -5,8 +5,8 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-windows10.0.17763.0'">
-    <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
+    <WindowsAppSdkBootstrapInitialize>true</WindowsAppSdkBootstrapInitialize>
   </PropertyGroup>
   <ItemGroup>
     <ExcludedCompileItems Include="@(Compile)" />


### PR DESCRIPTION
WinUI tests currently cannot use Xunit.StaFact to create controls or windows on a properly initialized STA dispatcher. This adds first-class WinUI support while following the existing WPF and WinForms threading model.

## Approach

- Add `WinUIFact`, `WinUITheory`, and `WinUIThreadFixture`.
- Create a fresh STA thread, DispatcherQueue, synchronization context, and XAML runtime for each test by default.
- Allow users to opt into a shared WinUI thread with the fixture, matching the existing WPF and WinForms precedent.
- Add an adapter cleanup hook because `DispatcherQueueSynchronizationContext` does not support synchronous `Send`.
- Preserve the existing `net8.0-windows` asset for WPF and WinForms consumers while adding `net8.0-windows10.0.17763.0` for WinUI and its Windows App SDK dependency.

Coverage includes controls and windows, async continuations, theories, retries, failures, skips, and shared fixture execution. Documentation describes the versioned Windows TFM requirement.

Fixes #77